### PR TITLE
chore: publish accepted SDK and Alchemy prerequisite base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ lerna-debug.log*
 
 # Turbo
 .turbo
+.wrangler/
+.alchemy/
 
 # PHP
 vendor/

--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -1,0 +1,19 @@
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+
+export default Alchemy.Stack(
+  "MonoWebPreview",
+  {
+    providers: Cloudflare.providers(),
+    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () {
+    const worker = yield* Cloudflare.Worker("PreviewSpine", {
+      main: "./infra/preview.worker.ts",
+      workersDev: { enabled: true, previewsEnabled: false },
+    });
+
+    return { url: worker.url.as<string>() };
+  }),
+);

--- a/bun.lock
+++ b/bun.lock
@@ -4,12 +4,19 @@
   "workspaces": {
     "": {
       "name": "monoweb",
+      "dependencies": {
+        "@effect/platform-bun": "4.0.0-beta.107",
+        "@effect/platform-node": "4.0.0-beta.107",
+        "alchemy": "2.0.0-beta.70",
+        "effect": "4.0.0-beta.107",
+      },
       "devDependencies": {
         "@changesets/cli": "^2.30.0",
         "oxfmt": "^0.26.0",
         "oxlint": "^1.41.0",
         "turbo": "^2.8.12",
         "typescript": "^5",
+        "wrangler": "4.120.0",
       },
     },
     "apps/dashboard": {
@@ -149,11 +156,9 @@
       "name": "@vektorprogrammet/sdk",
       "version": "0.2.0",
       "dependencies": {
-        "@effect/platform": "^0.96.0",
-        "effect": "^3.21.0",
+        "effect": "4.0.0-beta.107",
       },
       "devDependencies": {
-        "@effect/vitest": "^0.29.0",
         "@types/node": "^22",
         "typescript": "^5",
         "vitest": "^4.1.0",
@@ -169,7 +174,49 @@
 
     "@ai-sdk/ui-utils": ["@ai-sdk/ui-utils@1.2.11", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "zod-to-json-schema": "^3.24.1" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w=="],
 
+    "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.5", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw=="],
+
+    "@alchemy.run/node-utils": ["@alchemy.run/node-utils@0.0.5", "", {}, "sha512-5agdhQxWBodxa5hDRyjnpx91RTU3g+qd5fxYB7uNDCaOzB0XC47UU/KHR6zf6jhz/NXf61gJS+vhYwn8NHeRoQ=="],
+
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
+
+    "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.977.6", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@aws-sdk/xml-builder": "^3.972.37", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.31.1", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw=="],
+
+    "@aws-sdk/credential-provider-cognito-identity": ["@aws-sdk/credential-provider-cognito-identity@3.972.66", "", { "dependencies": { "@aws-sdk/nested-clients": "^3.997.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i4HTkP21eHaXA+XKoc6dYxlKPvYUqbusGGIsFRcSGTF8ln/q6RrWoRdVJ6UVODTCW59Ot1mVcbJXRAEf6kxa3w=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.67", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.69", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.12", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/credential-provider-env": "^3.972.67", "@aws-sdk/credential-provider-http": "^3.972.69", "@aws-sdk/credential-provider-login": "^3.972.74", "@aws-sdk/credential-provider-process": "^3.972.67", "@aws-sdk/credential-provider-sso": "^3.973.11", "@aws-sdk/credential-provider-web-identity": "^3.972.73", "@aws-sdk/nested-clients": "^3.997.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.74", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/nested-clients": "^3.997.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.78", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.67", "@aws-sdk/credential-provider-http": "^3.972.69", "@aws-sdk/credential-provider-ini": "^3.973.12", "@aws-sdk/credential-provider-process": "^3.972.67", "@aws-sdk/credential-provider-sso": "^3.973.11", "@aws-sdk/credential-provider-web-identity": "^3.972.73", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.67", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.11", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/nested-clients": "^3.997.41", "@aws-sdk/token-providers": "3.1103.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.73", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/nested-clients": "^3.997.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A=="],
+
+    "@aws-sdk/credential-providers": ["@aws-sdk/credential-providers@3.1106.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/credential-provider-cognito-identity": "^3.972.66", "@aws-sdk/credential-provider-env": "^3.972.67", "@aws-sdk/credential-provider-http": "^3.972.69", "@aws-sdk/credential-provider-ini": "^3.973.12", "@aws-sdk/credential-provider-login": "^3.972.74", "@aws-sdk/credential-provider-node": "^3.972.78", "@aws-sdk/credential-provider-process": "^3.972.67", "@aws-sdk/credential-provider-sso": "^3.973.11", "@aws-sdk/credential-provider-web-identity": "^3.972.73", "@aws-sdk/nested-clients": "^3.997.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-76a6HXmWZXgpQZRU3rnolfeMPPXrMvOfsQYlh7tkPXEgFrfdR6Hvo72uIQo57YVOBiOmVrwkTLA8NDNKbywTRQ=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.41", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/signature-v4-multi-region": "^3.996.43", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.43", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1103.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/nested-clients": "^3.997.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.37", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
 
     "@axe-core/playwright": ["@axe-core/playwright@4.11.1", "", { "dependencies": { "axe-core": "~4.11.1" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw=="],
 
@@ -395,69 +442,135 @@
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
 
+    "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@10.5.0", "", { "dependencies": { "@chevrotain/gast": "10.5.0", "@chevrotain/types": "10.5.0", "lodash": "4.17.21" } }, "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw=="],
+
+    "@chevrotain/gast": ["@chevrotain/gast@10.5.0", "", { "dependencies": { "@chevrotain/types": "10.5.0", "lodash": "4.17.21" } }, "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A=="],
+
+    "@chevrotain/types": ["@chevrotain/types@10.5.0", "", {}, "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A=="],
+
+    "@chevrotain/utils": ["@chevrotain/utils@10.5.0", "", {}, "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ=="],
+
+    "@clack/core": ["@clack/core@1.4.3", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ=="],
+
+    "@clack/prompts": ["@clack/prompts@1.7.0", "", { "dependencies": { "@clack/core": "1.4.3", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A=="],
+
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260801.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-wuJWbXpKvncJi1P0GKS+iYpN5tHdb7JPJJ/+6ZQe8zzovHHVMkLJPNBsgWpqeUhpM3g9qTwEKd2rglNKejuh5A=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260801.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kwoZiTpnhNrF3+APx84Q/oAqvJ3sU9yefGagwm/ASaH/2W19x0vghkW/r4qCoHCK0WW7EPugZ+aXjgPMRtlq1Q=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260801.1", "", { "os": "linux", "cpu": "x64" }, "sha512-r0vAxCZH+Jih9Unm1yoyiByPNWNgawcKciOHDm5Q37ZVGOkKLsT9AtLe3yLSaul76WrKqtf+JP2n0WW32VBLJg=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260801.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-zWgpdZtSozvIgzQNmQiDSF8yEOQJUkRAWNsDXXzAAoy+fCn8YUoSibj3mpFSbZRvbUldeBEaW6SCdC2VEMkhNQ=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260801.1", "", { "os": "win32", "cpu": "x64" }, "sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260810.1", "", {}, "sha512-aD0hEU6HaiG4wy4hDoPoLXMH963nHD4MsIY566pGkWO2dL/yeYEiMN7SeJ24t+wBmLDnh16yQ7IPos5opGkIoA=="],
+
     "@coreui/coreui": ["@coreui/coreui@2.0.18", "", { "dependencies": { "@coreui/coreui-plugin-npm-postinstall": "^1.0.2", "bootstrap": "^4.1.3" }, "peerDependencies": { "jquery": "1.9.1 - 3", "perfect-scrollbar": "^1.3.0", "popper.js": "^1.14.3" } }, "sha512-3P+ANdHpasPYNRsohj6vy0nA0aKcf1tG7Fw5tuPq/MqLSL/nHaBMi0UALIxQkDjU1VrdC8QzUfgxg+ydjnWl3A=="],
 
     "@coreui/coreui-plugin-npm-postinstall": ["@coreui/coreui-plugin-npm-postinstall@1.0.2", "", { "bin": { "coreui-plugin-npm-postinstall": "index.js" } }, "sha512-yeeoWp+bNS84nP1977Y8UCiQ9pssO+f4QuVj3i0/gYZFjjvOgxx0dnyWhtowD5sLYnCRMPlPpqyjwXze3SlkYg=="],
 
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
     "@discoveryjs/json-ext": ["@discoveryjs/json-ext@0.5.7", "", {}, "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw=="],
 
-    "@effect/platform": ["@effect/platform@0.96.0", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.4", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.21.0" } }, "sha512-U7PLhkVzg7zzrgFvyWATOzD6reL87KG/fcdOxgLWBQ/J5CCU6qdPAVG+0o6o+IxcsLoqGwxs+rFxaFzrdtDV1A=="],
+    "@distilled.cloud/aws": ["@distilled.cloud/aws@1.0.0-rc.2", "", { "dependencies": { "@aws-crypto/crc32": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/credential-providers": "^3.994.0", "@aws-sdk/types": "^3.973.1", "@distilled.cloud/core": "1.0.0-rc.2", "@smithy/shared-ini-file-loader": "^4.4.3", "@smithy/types": "^4.12.0", "@smithy/util-base64": "^4.3.0", "aws4fetch": "^1.0.20", "fast-xml-parser": "^5.3.2" }, "peerDependencies": { "effect": ">=4.0.0-beta.102 || >=4.0.0" } }, "sha512-hTWmdpfaKt6yLQ1YrJ17tp0DXINH7Wm5WQ05ap1FZW13Kwv+HzejXc4QPOYS6KT00Tlrfm6EEkTd3fDrY8dSGQ=="],
 
-    "@effect/vitest": ["@effect/vitest@0.29.0", "", { "peerDependencies": { "effect": "^3.21.0", "vitest": "^3.2.0" } }, "sha512-DvWr1aeEcaZ8mtu8hNVb4e3rEYvGEwQSr7wsNrW53t6nKYjkmjRICcvVEsXUhjoCblRHSxRsRV0TOt0+UmcvaQ=="],
+    "@distilled.cloud/axiom": ["@distilled.cloud/axiom@1.0.0-rc.2", "", { "dependencies": { "@distilled.cloud/core": "1.0.0-rc.2", "@effect/platform-bun": ">=4.0.0-beta.102 || >=4.0.0", "effect": ">=4.0.0-beta.102 || >=4.0.0" } }, "sha512-okRnWBdEQ6vYanYtiKbNzNJCgccEa7ZgeytHaNRTvIpHD4PlwG5WYwBsLkhTYjjudOvD5yjJ4H2N8dQQsJlGrg=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+    "@distilled.cloud/cloudflare": ["@distilled.cloud/cloudflare@1.0.0-rc.2", "", { "dependencies": { "@distilled.cloud/core": "1.0.0-rc.2", "@effect/platform-bun": ">=4.0.0-beta.102 || >=4.0.0", "effect": ">=4.0.0-beta.102 || >=4.0.0" } }, "sha512-GGO5I8OxY/0iUT2bj+Ug+ivrjS6V1/nvdMRfL8dLOrpBkIhR8AFkLPgdatBwdIWeJWRE5wdU4wy+aeHJNp3oJA=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+    "@distilled.cloud/cloudflare-rolldown-plugin": ["@distilled.cloud/cloudflare-rolldown-plugin@0.16.1", "", { "dependencies": { "@cloudflare/unenv-preset": "^2.16.0", "magic-string": "^0.30.21", "unenv": "^2.0.0-rc.24" }, "peerDependencies": { "rolldown": "~1.1.5", "vite": "^7.0.0 || ^8.0.0" }, "optionalPeers": ["rolldown", "vite"] }, "sha512-yj424SA0LMag1B6Ak/bhxEN3Wwg6j3Erv2xmRbcWgY1HbfZV5J1pUgRZ0RackjlSUAmCTRRxTrmZnQfqo5t2zQ=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+    "@distilled.cloud/cloudflare-runtime": ["@distilled.cloud/cloudflare-runtime@0.16.1", "", { "dependencies": { "@alchemy.run/node-utils": "^0.0.5", "@puppeteer/browsers": "^2.10.6", "sharp": "^0.34.5", "workerd": "1.20260704.1" }, "peerDependencies": { "@distilled.cloud/cloudflare": "^0.30.3", "@effect/platform-bun": ">=4.0.0-beta.102 || >=4.0.0", "@effect/platform-node": ">=4.0.0-beta.102 || >=4.0.0", "effect": ">=4.0.0-beta.102 || >=4.0.0" }, "optionalPeers": ["@effect/platform-bun", "@effect/platform-node"] }, "sha512-kubDEVDpkbXxNY56TnoXQGaAc0az2IA7SQsBkhgCnN538Vn9LGXTOJ1534AzFhKtfmrVxzj0rtcd5cPKBNTn4A=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+    "@distilled.cloud/cloudflare-vite-plugin": ["@distilled.cloud/cloudflare-vite-plugin@0.16.1", "", { "dependencies": { "@distilled.cloud/cloudflare-rolldown-plugin": "0.16.1" }, "peerDependencies": { "@distilled.cloud/cloudflare": "^0.30.3", "@distilled.cloud/cloudflare-runtime": "0.16.1", "@effect/platform-bun": ">=4.0.0-beta.102 || >=4.0.0", "@effect/platform-node": ">=4.0.0-beta.102 || >=4.0.0", "effect": ">=4.0.0-beta.102 || >=4.0.0", "vite": "^7.0.0 || ^8.0.0" }, "optionalPeers": ["@effect/platform-bun", "@effect/platform-node"] }, "sha512-OzVZlegqYqt/bNdVHOVKp/vBnUU1+Cdfymu2yBJioAOjNIJEW2uKUKm6KwHZf29HlgGDh2jSruqOWui86kM6Gg=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+    "@distilled.cloud/core": ["@distilled.cloud/core@1.0.0-rc.2", "", { "peerDependencies": { "effect": ">=4.0.0-beta.102 || >=4.0.0" } }, "sha512-cVswTWsqC15Z9EPAOdRpfTG4UU8JPXhQEeH2ThW7Yh2BRl4lhIIOdxbRqUsRXPDMn24Mn08h2C3A6MGKP/KwLA=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+    "@distilled.cloud/neon": ["@distilled.cloud/neon@1.0.0-rc.2", "", { "dependencies": { "@distilled.cloud/core": "1.0.0-rc.2", "@effect/platform-bun": ">=4.0.0-beta.102 || >=4.0.0", "effect": ">=4.0.0-beta.102 || >=4.0.0" } }, "sha512-j1SRh/ionzWDeS8nO3+zF8h2zHNOddmTfqeev5LBs1pKeQWBJ3ZVDK3GeBACZzaeW3rCcll8eJEZ6fRnrp3xbw=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+    "@distilled.cloud/planetscale": ["@distilled.cloud/planetscale@1.0.0-rc.2", "", { "dependencies": { "@distilled.cloud/core": "1.0.0-rc.2", "@effect/platform-bun": ">=4.0.0-beta.102 || >=4.0.0", "effect": ">=4.0.0-beta.102 || >=4.0.0" } }, "sha512-ucuQ0VM3bmovjzHoC/C7uo9634EQOJcI1gzx0jjdE2QIDsvy56UhjT3alilq9kADGz1V0/LUHOV3Xf1VqJf6Nw=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.107", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.107" }, "peerDependencies": { "effect": "^4.0.0-beta.107" } }, "sha512-nDKutCpgr+xHQX7tgN8Cq6JXtj96GqiElKaJ7AwAkZYl2q9f6onc/3aJgl6CyH/DlUoidw6YaxeU+UaTRmMN1g=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.107", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.107", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.107", "ioredis": ">=5.7.0 <6.0.0" } }, "sha512-k+6YNbV4Ck0L6YXtlgkvEnuP5tlxWD8EeWOrpn46PDqbGEwt4ONpRltTwm3tn2cyBXD0i+2P11cUH/6sdFagTA=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.107", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.107" } }, "sha512-y6BqcRi86BfTJv+tvDrob4ozYVHxxlHYcn/zIQqZjXI9CvKnkgD6ng+38G1o45c4f2ucU+6HRI9POCmFdMoVGA=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+    "@effect/sql-d1": ["@effect/sql-d1@4.0.0-beta.107", "", { "dependencies": { "@cloudflare/workers-types": "^5.20260708.1" }, "peerDependencies": { "effect": "^4.0.0-beta.107" } }, "sha512-GN0RMZRQ+Kc6t4hiIbGBFMdYj2UssX27w0n1oyV+s9OZcWOdD42C2vDxUwnnKLstPDdeOMBAFX7dMekOiF2rUQ=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+    "@effect/sql-sqlite-do": ["@effect/sql-sqlite-do@4.0.0-beta.107", "", { "peerDependencies": { "effect": "^4.0.0-beta.107" } }, "sha512-masFQKrc0MMWT3898133Mc6O76WosTmhtlPRaNlfYz0NBDTfrsogUoZ7bTizmBUEIngRaKFNwRJpeO/PusiE+g=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+    "@effect/vitest": ["@effect/vitest@4.0.0-beta.107", "", { "peerDependencies": { "effect": "^4.0.0-beta.107", "vitest": ">=4.1.0 <5.0.0" } }, "sha512-n4/qsx4DnT4dEI/wNgMivxyUeJoeiU1TCSz0WnoHWk/dny40Oxjip2P9IXGQDgPb9fsYVnerF0QRA6nPUuExQA=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+    "@electric-sql/pglite": ["@electric-sql/pglite@0.3.15", "", {}, "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+    "@electric-sql/pglite-socket": ["@electric-sql/pglite-socket@0.0.20", "", { "peerDependencies": { "@electric-sql/pglite": "0.3.15" }, "bin": { "pglite-server": "dist/scripts/server.js" } }, "sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+    "@electric-sql/pglite-tools": ["@electric-sql/pglite-tools@0.2.20", "", { "peerDependencies": { "@electric-sql/pglite": "0.3.15" } }, "sha512-BK50ZnYa3IG7ztXhtgYf0Q7zijV32Iw1cYS8C+ThdQlwx12V5VZ9KRJ42y82Hyb4PkTxZQklVQA9JHyUlex33A=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+    "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
 
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 
@@ -469,61 +582,69 @@
 
     "@fortawesome/fontawesome-free": ["@fortawesome/fontawesome-free@5.4.1", "", {}, "sha512-ZcxfUmLFl4RLG71cPeZcTXRa6rt3xLnMmomAb7aYKRzUmlRRj7E8EVqSwYSXBiV2x6XpSQmGOQmNQx6HSeSwVQ=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
+
     "@hookform/resolvers": ["@hookform/resolvers@4.1.3", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.0.0" } }, "sha512-Jsv6UOWYTrEFJ/01ZrnwVXs7KDvP8XIo115i++5PWvNkNvkrsTfGiLS6w+eJ57CYtUtDQalUWovCZDHFJ8u1VQ=="],
 
     "@icons-pack/react-simple-icons": ["@icons-pack/react-simple-icons@12.9.0", "", { "peerDependencies": { "react": "^16.13 || ^17 || ^18 || ^19" } }, "sha512-GLb2ayO78ZjjmI7GMpCDlXcELEr3DPO89nordI/JC8dMiJDMzuPb3qeOTt+SWcFOyJ+SAh9C/feUCpiBSM8ZLQ=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.1" }, "os": "darwin", "cpu": "arm64" }, "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg=="],
 
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.1" }, "os": "darwin", "cpu": "x64" }, "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw=="],
 
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+    "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.2", "", { "dependencies": { "@img/sharp-wasm32": "0.35.2" }, "os": "freebsd" }, "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw=="],
 
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g=="],
 
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ=="],
 
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.1", "", { "os": "linux", "cpu": "arm" }, "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg=="],
 
-    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw=="],
 
-    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng=="],
 
-    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.1", "", { "os": "linux", "cpu": "none" }, "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw=="],
 
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew=="],
 
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A=="],
 
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw=="],
 
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg=="],
 
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.1" }, "os": "linux", "cpu": "arm" }, "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A=="],
 
-    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA=="],
 
-    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.1" }, "os": "linux", "cpu": "ppc64" }, "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg=="],
 
-    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.1" }, "os": "linux", "cpu": "none" }, "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA=="],
 
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.1" }, "os": "linux", "cpu": "s390x" }, "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA=="],
 
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA=="],
 
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg=="],
 
     "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
 
-    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+    "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.2", "", { "dependencies": { "@img/sharp-wasm32": "0.35.2" }, "cpu": "none" }, "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g=="],
 
-    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ=="],
 
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.2", "", { "os": "win32", "cpu": "x64" }, "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
+
+    "@ioredis/commands": ["@ioredis/commands@1.10.0", "", {}, "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -536,6 +657,32 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@libsql/client": ["@libsql/client@0.17.4", "", { "dependencies": { "@libsql/core": "^0.17.4", "@libsql/hrana-client": "^0.10.0", "js-base64": "^3.7.5", "libsql": "^0.5.28", "promise-limit": "^2.7.0" } }, "sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw=="],
+
+    "@libsql/core": ["@libsql/core@0.17.4", "", { "dependencies": { "js-base64": "^3.7.5" } }, "sha512-LqF9gIvnJ38nmAH1y/ChizHqDO/MO1wLgA96XrraulEEbqXxLjleSH92YWTolbuJKgPUmGu4aJk9W3UnAcxLOQ=="],
+
+    "@libsql/darwin-arm64": ["@libsql/darwin-arm64@0.5.29", "", { "os": "darwin", "cpu": "arm64" }, "sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A=="],
+
+    "@libsql/darwin-x64": ["@libsql/darwin-x64@0.5.29", "", { "os": "darwin", "cpu": "x64" }, "sha512-OtT+KFHsKFy1R5FVadr8FJ2Bb1mghtXTyJkxv0trocq7NuHntSki1eUbxpO5ezJesDvBlqFjnWaYYY516QNLhQ=="],
+
+    "@libsql/hrana-client": ["@libsql/hrana-client@0.10.0", "", { "dependencies": { "@libsql/isomorphic-ws": "^0.1.5", "js-base64": "^3.7.5" } }, "sha512-OoA4EMqRAC7kn7V2P6EQqRcpZf2W+AjsNIyCizBg339Tq/aMC7sRnzs3SklderhmQWAqEzvv8A2vhxVmWpkVvw=="],
+
+    "@libsql/isomorphic-ws": ["@libsql/isomorphic-ws@0.1.5", "", { "dependencies": { "@types/ws": "^8.5.4", "ws": "^8.13.0" } }, "sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg=="],
+
+    "@libsql/linux-arm-gnueabihf": ["@libsql/linux-arm-gnueabihf@0.5.29", "", { "os": "linux", "cpu": "arm" }, "sha512-CD4n4zj7SJTHso4nf5cuMoWoMSS7asn5hHygsDuhRl8jjjCTT3yE+xdUvI4J7zsyb53VO5ISh4cwwOtf6k2UhQ=="],
+
+    "@libsql/linux-arm-musleabihf": ["@libsql/linux-arm-musleabihf@0.5.29", "", { "os": "linux", "cpu": "arm" }, "sha512-2Z9qBVpEJV7OeflzIR3+l5yAd4uTOLxklScYTwpZnkm2vDSGlC1PRlueLaufc4EFITkLKXK2MWBpexuNJfMVcg=="],
+
+    "@libsql/linux-arm64-gnu": ["@libsql/linux-arm64-gnu@0.5.29", "", { "os": "linux", "cpu": "arm64" }, "sha512-gURBqaiXIGGwFNEaUj8Ldk7Hps4STtG+31aEidCk5evMMdtsdfL3HPCpvys+ZF/tkOs2MWlRWoSq7SOuCE9k3w=="],
+
+    "@libsql/linux-arm64-musl": ["@libsql/linux-arm64-musl@0.5.29", "", { "os": "linux", "cpu": "arm64" }, "sha512-fwgYZ0H8mUkyVqXZHF3mT/92iIh1N94Owi/f66cPVNsk9BdGKq5gVpoKO+7UxaNzuEH1roJp2QEwsCZMvBLpqg=="],
+
+    "@libsql/linux-x64-gnu": ["@libsql/linux-x64-gnu@0.5.29", "", { "os": "linux", "cpu": "x64" }, "sha512-y14V0vY0nmMC6G0pHeJcEarcnGU2H6cm21ZceRkacWHvQAEhAG0latQkCtoS2njFOXiYIg+JYPfAoWKbi82rkg=="],
+
+    "@libsql/linux-x64-musl": ["@libsql/linux-x64-musl@0.5.29", "", { "os": "linux", "cpu": "x64" }, "sha512-gquqwA/39tH4pFl+J9n3SOMSymjX+6kZ3kWgY3b94nXFTwac9bnFNMffIomgvlFaC4ArVqMnOZD3nuJ3H3VO1w=="],
+
+    "@libsql/win32-x64-msvc": ["@libsql/win32-x64-msvc@0.5.29", "", { "os": "win32", "cpu": "x64" }, "sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg=="],
 
     "@mantine/hooks": ["@mantine/hooks@7.17.8", "", { "peerDependencies": { "react": "^18.x || ^19.x" } }, "sha512-96qygbkTjRhdkzd5HDU8fMziemN/h758/EwrFu7TlWrEP10Vw076u+Ap/sG6OT4RGPZYYoHrTlT+mkCZblWHuw=="],
 
@@ -551,17 +698,23 @@
 
     "@monoweb/server": ["@monoweb/server@workspace:apps/server"],
 
-    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
+    "@mrleebo/prisma-ast": ["@mrleebo/prisma-ast@0.13.1", "", { "dependencies": { "chevrotain": "^10.5.0", "lilconfig": "^2.1.0" } }, "sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw=="],
 
-    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw=="],
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
-    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw=="],
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
 
-    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg=="],
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
 
-    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg=="],
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
 
-    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ=="],
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3" } }, "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw=="],
+
+    "@neon-rs/load": ["@neon-rs/load@0.0.4", "", {}, "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw=="],
 
     "@next/bundle-analyzer": ["@next/bundle-analyzer@15.5.12", "", { "dependencies": { "webpack-bundle-analyzer": "4.10.1" } }, "sha512-tDkdfvuKz9JlH+B/CEIY0+XqQ5gymVZZWvDer5HJI68rPI0EYfbSadbvIUvHTugYnMkyxSBf8u0P2yGOSQ4h+w=="],
 
@@ -583,13 +736,47 @@
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.12", "", { "os": "win32", "cpu": "x64" }, "sha512-Z1Dh6lhFkxvBDH1FoW6OU/L6prYwPSlwjLiZkExIAh8fbP6iI/M7iGTQAJPYJ9YFlWobCZ1PHbchFhFYb2ADkw=="],
 
+    "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
+
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
+    "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
+
+    "@octokit/core": ["@octokit/core@7.0.7", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.4", "@octokit/request": "^10.0.13", "@octokit/request-error": "^7.1.1", "@octokit/types": "^17.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA=="],
+
+    "@octokit/endpoint": ["@octokit/endpoint@11.0.4", "", { "dependencies": { "@octokit/types": "^17.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA=="],
+
+    "@octokit/graphql": ["@octokit/graphql@9.0.4", "", { "dependencies": { "@octokit/request": "^10.0.13", "@octokit/types": "^17.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg=="],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@28.0.0", "", {}, "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ=="],
+
+    "@octokit/openapi-webhooks-types": ["@octokit/openapi-webhooks-types@12.1.0", "", {}, "sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA=="],
+
+    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@14.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw=="],
+
+    "@octokit/plugin-request-log": ["@octokit/plugin-request-log@6.0.0", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q=="],
+
+    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
+
+    "@octokit/request": ["@octokit/request@10.0.13", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.1.1", "@octokit/types": "^17.0.0", "content-type": "^2.0.0", "json-with-bigint": "^3.5.3", "universal-user-agent": "^7.0.2" } }, "sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A=="],
+
+    "@octokit/request-error": ["@octokit/request-error@7.1.1", "", { "dependencies": { "@octokit/types": "^17.0.0" } }, "sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA=="],
+
+    "@octokit/rest": ["@octokit/rest@22.0.1", "", { "dependencies": { "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-request-log": "^6.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0" } }, "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw=="],
+
+    "@octokit/types": ["@octokit/types@17.0.0", "", { "dependencies": { "@octokit/openapi-types": "^28.0.0" } }, "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q=="],
+
+    "@octokit/webhooks": ["@octokit/webhooks@14.2.0", "", { "dependencies": { "@octokit/openapi-webhooks-types": "12.1.0", "@octokit/request-error": "^7.0.0", "@octokit/webhooks-methods": "^6.0.0" } }, "sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw=="],
+
+    "@octokit/webhooks-methods": ["@octokit/webhooks-methods@6.0.0", "", {}, "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ=="],
+
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
 
     "@oxfmt/darwin-arm64": ["@oxfmt/darwin-arm64@0.26.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-AAGc+8CffkiWeVgtWf4dPfQwHEE5c/j/8NWH7VGVxxJRCZFdmWcqCXprvL2H6qZFewvDLrFbuSPRCqYCpYGaTQ=="],
 
@@ -678,6 +865,22 @@
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
     "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
+
+    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
+
+    "@prisma/debug": ["@prisma/debug@7.2.0", "", {}, "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw=="],
+
+    "@prisma/dev": ["@prisma/dev@0.20.0", "", { "dependencies": { "@electric-sql/pglite": "0.3.15", "@electric-sql/pglite-socket": "0.0.20", "@electric-sql/pglite-tools": "0.2.20", "@hono/node-server": "1.19.9", "@mrleebo/prisma-ast": "0.13.1", "@prisma/get-platform": "7.2.0", "@prisma/query-plan-executor": "7.2.0", "foreground-child": "3.3.1", "get-port-please": "3.2.0", "hono": "4.11.4", "http-status-codes": "2.3.0", "pathe": "2.0.3", "proper-lockfile": "4.1.2", "remeda": "2.33.4", "std-env": "3.10.0", "valibot": "1.2.0", "zeptomatch": "2.1.0" } }, "sha512-ovlBYwWor0OzG+yH4J3Ot+AneD818BttLA+Ii7wjbcLHUrnC4tbUPVGyNd3c/+71KETPKZfjhkTSpdS15dmXNQ=="],
+
+    "@prisma/get-platform": ["@prisma/get-platform@7.2.0", "", { "dependencies": { "@prisma/debug": "7.2.0" } }, "sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA=="],
+
+    "@prisma/query-plan-executor": ["@prisma/query-plan-executor@7.2.0", "", {}, "sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ=="],
+
+    "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -779,6 +982,38 @@
 
     "@remix-run/node-fetch-server": ["@remix-run/node-fetch-server@0.13.0", "", {}, "sha512-1EsNo0ZpgXu/90AWoRZf/oE3RVTUS80tiTUpt+hv5pjtAkw7icN4WskDwz/KdAw5ARbJLMhZBrO1NqThmy/McA=="],
 
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.5", "", { "os": "linux", "cpu": "arm" }, "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.5", "", { "os": "none", "cpu": "arm64" }, "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
 
     "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.59.0", "", { "os": "android", "cpu": "arm64" }, "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q=="],
@@ -828,6 +1063,34 @@
     "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
+
+    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
+    "@smithy/core": ["@smithy/core@3.31.1", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.16", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.13", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/node-config-provider": ["@smithy/node-config-provider@4.5.16", "", { "dependencies": { "@smithy/core": "^3.31.1", "tslib": "^2.6.2" } }, "sha512-N4XTMCO77u8jXq9Ms1pbFM3M9zD+ScKnvB+M7//VyawM8L6xW3/mqAPp/uMOYprW+q/b1Qen6qUKVwxTb2ymiQ=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.13", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw=="],
+
+    "@smithy/shared-ini-file-loader": ["@smithy/shared-ini-file-loader@4.6.16", "", { "dependencies": { "@smithy/core": "^3.31.1", "tslib": "^2.6.2" } }, "sha512-apuIuit7x6ZM0nJxuKf24MCkflwnSyD6wePOPGkhntEl0gLaIYLlZTQtzCB+j3kWOTpqx0D1o6JZ15NTk4f8xQ=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.6.12", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ=="],
+
+    "@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@smithy/util-base64": ["@smithy/util-base64@4.5.16", "", { "dependencies": { "@smithy/core": "^3.31.1", "tslib": "^2.6.2" } }, "sha512-80e25qWKD6hJh5BenAutni2Z6dj2AiZKmht21pcROmzWzQja8yl+KqsuDSia++hwk1Ne6RrDEBwP6I+A4R0XAg=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.24", "", {}, "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -941,6 +1204,12 @@
 
     "@tiptap/starter-kit": ["@tiptap/starter-kit@2.27.2", "", { "dependencies": { "@tiptap/core": "^2.27.2", "@tiptap/extension-blockquote": "^2.27.2", "@tiptap/extension-bold": "^2.27.2", "@tiptap/extension-bullet-list": "^2.27.2", "@tiptap/extension-code": "^2.27.2", "@tiptap/extension-code-block": "^2.27.2", "@tiptap/extension-document": "^2.27.2", "@tiptap/extension-dropcursor": "^2.27.2", "@tiptap/extension-gapcursor": "^2.27.2", "@tiptap/extension-hard-break": "^2.27.2", "@tiptap/extension-heading": "^2.27.2", "@tiptap/extension-history": "^2.27.2", "@tiptap/extension-horizontal-rule": "^2.27.2", "@tiptap/extension-italic": "^2.27.2", "@tiptap/extension-list-item": "^2.27.2", "@tiptap/extension-ordered-list": "^2.27.2", "@tiptap/extension-paragraph": "^2.27.2", "@tiptap/extension-strike": "^2.27.2", "@tiptap/extension-text": "^2.27.2", "@tiptap/extension-text-style": "^2.27.2", "@tiptap/pm": "^2.27.2" } }, "sha512-bb0gJvPoDuyRUQ/iuN52j1//EtWWttw+RXAv1uJxfR0uKf8X7uAqzaOOgwjknoCIDC97+1YHwpGdnRjpDkOBxw=="],
 
+    "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "@types/aws-lambda": ["@types/aws-lambda@8.10.162", "", {}, "sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -966,6 +1235,10 @@
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
     "@vektorprogrammet/sdk": ["@vektorprogrammet/sdk@workspace:packages/sdk"],
 
@@ -1003,17 +1276,27 @@
 
     "aes-decrypter": ["aes-decrypter@4.0.2", "", { "dependencies": { "@babel/runtime": "^7.12.5", "@videojs/vhs-utils": "^4.1.1", "global": "^4.4.0", "pkcs7": "^1.0.4" } }, "sha512-lc+/9s6iJvuaRe5qDlMTpCFjnwpkeOXp8qP3oiZ5jsj1MRg+SBVUmmICrhxHvc8OELSmc+fEyyxAuppY6hrWzw=="],
 
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
     "ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
 
+    "alchemy": ["alchemy@2.0.0-beta.70", "", { "dependencies": { "@alchemy.run/node-utils": "0.0.5", "@aws-sdk/credential-providers": "^3.0.0", "@clack/prompts": "^1.7.0", "@distilled.cloud/aws": "1.0.0-rc.2", "@distilled.cloud/axiom": "1.0.0-rc.2", "@distilled.cloud/cloudflare": "1.0.0-rc.2", "@distilled.cloud/cloudflare-rolldown-plugin": "0.16.1", "@distilled.cloud/cloudflare-runtime": "0.16.1", "@distilled.cloud/cloudflare-vite-plugin": "0.16.1", "@distilled.cloud/core": "1.0.0-rc.2", "@distilled.cloud/neon": "1.0.0-rc.2", "@distilled.cloud/planetscale": "1.0.0-rc.2", "@effect/sql-d1": ">=4.0.0-beta.102 || >=4.0.0", "@effect/sql-sqlite-do": ">=4.0.0-beta.102 || >=4.0.0", "@effect/vitest": ">=4.0.0-beta.102 || >=4.0.0", "@libsql/client": "^0.17.0", "@octokit/rest": "^22.0.1", "@octokit/webhooks": "^14.2.0", "@prisma/dev": "^0.20.0", "@smithy/node-config-provider": "^4.0.0", "@smithy/shared-ini-file-loader": "^4.3.4", "@smithy/types": "^4.8.1", "@types/aws-lambda": "^8.10.152", "aws4fetch": "^1.0.20", "capnweb": "^0.6.1", "fast-glob": "^3.3.2", "fast-xml-parser": "^5.3.4", "ink": "^6.3.1", "jszip": "^3.10.1", "libsodium-wrappers": "^0.8.3", "pathe": "^2.0.3", "picomatch": "^4.0.4", "react": "^19.2.0", "rolldown": "1.1.5", "undici": "^7.16.0", "yaml": "^2.0.0" }, "peerDependencies": { "@aws/durable-execution-sdk-js": "^2.1.0", "@effect/platform-bun": ">=4.0.0-beta.102 || >=4.0.0", "@effect/platform-node": ">=4.0.0-beta.102 || >=4.0.0", "@effect/sql-mysql2": ">=4.0.0-beta.102 || >=4.0.0", "@effect/sql-pg": ">=4.0.0-beta.102 || >=4.0.0", "@vercel/nft": "^1.10.2", "drizzle-kit": "1.0.0-rc.4", "drizzle-orm": "1.0.0-rc.4", "effect": ">=4.0.0-beta.102 || >=4.0.0", "mongodb": "^6.10.0", "mysql2": "^3.15.3", "pg": "^8.13.0", "vite": "^8.0.7", "ws": "^8.20.0" }, "optionalPeers": ["@aws/durable-execution-sdk-js", "@effect/platform-bun", "@effect/platform-node", "@effect/sql-mysql2", "@effect/sql-pg", "@vercel/nft", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "pg", "vite", "ws"], "bin": { "alchemy": "bin/cli.js" } }, "sha512-ITaYMa061cYuXHGP4xdS0+HsP5smpNl58f+eIja8egvJwzpwGbPt2aK0y+vDMH+44iMAsfrH7yTOKm7H5DN4cg=="],
+
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
+    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
+
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
 
     "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
 
@@ -1027,11 +1310,19 @@
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
+    "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
+
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
     "autoprefixer": ["autoprefixer@10.4.27", "", { "dependencies": { "browserslist": "^4.28.1", "caniuse-lite": "^1.0.30001774", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA=="],
 
+    "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
+
     "axe-core": ["axe-core@4.11.1", "", {}, "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A=="],
+
+    "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
 
     "babel-dead-code-elimination": ["babel-dead-code-elimination@1.0.12", "", { "dependencies": { "@babel/core": "^7.23.7", "@babel/parser": "^7.23.6", "@babel/traverse": "^7.23.7", "@babel/types": "^7.23.6" } }, "sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig=="],
 
@@ -1045,9 +1336,21 @@
 
     "barbe": ["barbe@2.2.1", "", { "dependencies": { "regex-escape": "^3.0.0" } }, "sha512-yx9qVTYLHqoglkWensOg8lBe/OPiFhcttEsQhs8d4tYvZoQbkGwDQ1R6I2uLijTCCylQXX4nIGVIlcaKf0fO4Q=="],
 
+    "bare-events": ["bare-events@2.9.1", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg=="],
+
+    "bare-fs": ["bare-fs@4.8.0", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-fM+MhCvdQhZ7NV6S95a07gPSqjIYKn6mFaXfx266wN3ajZGl/+1AzH+ubkXQ0fFZvOe2nk9VHkzdYkQE5zMV3Q=="],
+
+    "bare-path": ["bare-path@3.1.1", "", {}, "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ=="],
+
+    "bare-stream": ["bare-stream@2.13.3", "", { "dependencies": { "b4a": "^1.8.1", "streamx": "^2.25.0", "teex": "^1.0.1" }, "peerDependencies": { "bare-abort-controller": "*", "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-abort-controller", "bare-buffer", "bare-events"] }, "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ=="],
+
+    "bare-url": ["bare-url@2.5.1", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-cD5ciQuKlx+eumTCfqbfiL+fhQm+dHbVNB/cX4+d+I/nx4JsVop9VoFEPAs5RJ6I84QR6bZIBjpd2kjDOYeWcg=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.0", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA=="],
 
     "basic-auth": ["basic-auth@2.0.1", "", { "dependencies": { "safe-buffer": "5.1.2" } }, "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg=="],
+
+    "basic-ftp": ["basic-ftp@5.3.1", "", {}, "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="],
 
     "bcp-47": ["bcp-47@1.0.8", "", { "dependencies": { "is-alphabetical": "^1.0.0", "is-alphanumerical": "^1.0.0", "is-decimal": "^1.0.0" } }, "sha512-Y9y1QNBBtYtv7hcmoX0tR+tUNSFZGZ6OL6vKPObq8BbOhkCoyayF6ogfLTgAli/KuAEbsYHYUNq2AQuY6IuLag=="],
 
@@ -1055,13 +1358,19 @@
 
     "bcp-47-normalize": ["bcp-47-normalize@1.1.1", "", { "dependencies": { "bcp-47": "^1.0.0", "bcp-47-match": "^1.0.0" } }, "sha512-jWZ1Jdu3cs0EZdfCkS0UE9Gg01PtxnChjEBySeB+Zo6nkqtFfnvtoQQgP1qU1Oo4qgJgxhTI6Sf9y/pZIhPs0A=="],
 
+    "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
+
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
     "body-parser": ["body-parser@1.20.4", "", { "dependencies": { "bytes": "~3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "~1.2.0", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "on-finished": "~2.4.1", "qs": "~6.14.0", "raw-body": "~2.5.3", "type-is": "~1.6.18", "unpipe": "~1.0.0" } }, "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA=="],
 
     "bootstrap": ["bootstrap@4.6.2", "", { "peerDependencies": { "jquery": "1.9.1 - 3", "popper.js": "^1.16.1" } }, "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -1070,6 +1379,8 @@
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
     "browserslist-to-esbuild": ["browserslist-to-esbuild@2.1.1", "", { "dependencies": { "meow": "^13.0.0" }, "peerDependencies": { "browserslist": "*" }, "bin": { "browserslist-to-esbuild": "cli/index.js" } }, "sha512-KN+mty6C3e9AN8Z5dI1xeN15ExcRNeISoC3g7V0Kax/MMF9MSoYA2G7lkTTcVUFntiEjkpI0HNgqJC1NjdyNUw=="],
+
+    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -1085,6 +1396,8 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001776", "", {}, "sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw=="],
 
+    "capnweb": ["capnweb@0.6.1", "", {}, "sha512-fmhV26QPd1ewf5R74h55oVZnGwIcSaRMzbfLQUy8+zOBjuTmT3KXoT8wxHvnp1m9Ht9BoUUS5ZwNLoVLfQTyBg=="],
+
     "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
@@ -1093,19 +1406,37 @@
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
+    "chevrotain": ["chevrotain@10.5.0", "", { "dependencies": { "@chevrotain/cst-dts-gen": "10.5.0", "@chevrotain/gast": "10.5.0", "@chevrotain/types": "10.5.0", "@chevrotain/utils": "10.5.0", "lodash": "4.17.21", "regexp-to-ast": "0.5.0" } }, "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A=="],
+
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "ckeditor": ["ckeditor@4.5.10", "", {}, "sha512-dV4FyutWXhgABEVFZtHHWlIq7/XUmv4DgHFHu3/7CDcw/VxyqXb3uAn9Jq9UVB9JlJSJ/bs2OZMBOdDRoz7WUQ=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
+    "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
+
+    "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
+
+    "cli-truncate": ["cli-truncate@5.2.0", "", { "dependencies": { "slice-ansi": "^8.0.0", "string-width": "^8.2.0" } }, "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw=="],
+
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "cluster-key-slot": ["cluster-key-slot@1.1.1", "", {}, "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw=="],
+
     "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
 
+    "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
+
     "codem-isoboxer": ["codem-isoboxer@0.3.9", "", {}, "sha512-4XOTqEzBWrGOZaMd+sTED2hLpzfBbiQCf1W6OBGkIHqk1D8uwy8WFLazVbdQwfDpQ+vf39lqTGPa9IhWW0roTA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
@@ -1123,6 +1454,8 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
+
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "cookie-signature": ["cookie-signature@1.0.7", "", {}, "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="],
@@ -1130,6 +1463,8 @@
     "core-js": ["core-js@3.48.0", "", {}, "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ=="],
 
     "core-js-compat": ["core-js-compat@3.48.0", "", { "dependencies": { "browserslist": "^4.28.1" } }, "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q=="],
+
+    "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
     "create-gi": ["create-gi@1.0.4", "", { "bin": { "create-gi": "index.js" } }, "sha512-mjVUIrg+sNv9lrVr+zirmlPX7dr4ExChW5RbKgH1GsSUFDfMJ2NFPTtwdVDGm1YygTfNkbSwrvF8e7XmN09D2w=="],
 
@@ -1151,6 +1486,8 @@
 
     "dashjs": ["dashjs@4.7.4", "", { "dependencies": { "bcp-47-match": "^1.0.3", "bcp-47-normalize": "^1.1.1", "codem-isoboxer": "0.3.9", "es6-promise": "^4.2.8", "fast-deep-equal": "2.0.1", "html-entities": "^1.2.1", "imsc": "^1.1.5", "localforage": "^1.7.1", "path-browserify": "^1.0.1", "ua-parser-js": "^1.0.37" } }, "sha512-+hldo25QPP3H/NOwqUrvt4uKdMse60/Gsz9AUAnoYfhga8qHWq4nWiojUosOiigbigkDTCAn9ORcvUaKCvmfCA=="],
 
+    "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
+
     "dayjs": ["dayjs@1.11.19", "", {}, "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw=="],
 
     "debounce": ["debounce@1.2.1", "", {}, "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="],
@@ -1161,7 +1498,11 @@
 
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
 
+    "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
@@ -1193,21 +1534,29 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
-    "effect": ["effect@3.21.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ=="],
+    "effect": ["effect@4.0.0-beta.107", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "uuid": "^14.0.1" } }, "sha512-OoBAv8eF+yanc+C6xhgEUnWeXUSHA6ynnscYqpkAY9GSnzZWystsIjBowVqCkLpHGlnRtdIqYT3wHwpOY6JDnQ=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.307", "", {}, "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg=="],
 
     "emojer": ["emojer@1.1.6", "", { "dependencies": { "barbe": "^2.2.1", "match-all": "^1.1.1", "regex-emoji": "^2.0.1" } }, "sha512-0rNJBx2tBbao/1PIZMWk5Ym2oIlGUUkFOM2ldyWcJkxGr2qGJ+AcY6o+LdAfgEti6jTKTHoq/8Lnx9Ic+dtlNQ=="],
 
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "encriptorjs": ["encriptorjs@1.0.2", "", {}, "sha512-+gnlMVYUAWnmX60CPkyeCoBLiYOLgkbljATUpNFeIUHA6x8O6XdPRprCBc+cnfnqjCtSNA7ozgAHmukbXzaF+Q=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.20.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -1219,17 +1568,23 @@
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
+    "es-toolkit": ["es-toolkit@1.50.0", "", {}, "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w=="],
+
     "es6-promise": ["es6-promise@4.2.8", "", {}, "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="],
 
-    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
-    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+    "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+
+    "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
@@ -1238,6 +1593,8 @@
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
 
     "exit-hook": ["exit-hook@2.2.1", "", {}, "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw=="],
 
@@ -1249,11 +1606,25 @@
 
     "extendable-error": ["extendable-error@0.1.7", "", {}, "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="],
 
-    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+    "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
+
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
+    "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
+
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
+
+    "fast-xml-builder": ["fast-xml-builder@1.3.0", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.10.1", "", { "dependencies": { "@nodable/entities": "^3.0.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^2.0.0", "path-expression-matcher": "^1.6.2", "strnum": "^2.4.1", "xml-naming": "^0.3.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw=="],
 
     "fastparse": ["fastparse@1.1.2", "", {}, "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="],
 
@@ -1261,15 +1632,17 @@
 
     "fault": ["fault@1.0.4", "", { "dependencies": { "format": "^0.2.0" } }, "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA=="],
 
+    "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "finalhandler": ["finalhandler@1.3.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "statuses": "~2.0.2", "unpipe": "~1.0.0" } }, "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg=="],
 
-    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
-
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
@@ -1295,15 +1668,25 @@
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
     "get-port": ["get-port@5.1.1", "", {}, "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="],
 
+    "get-port-please": ["get-port-please@3.2.0", "", {}, "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A=="],
+
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
+    "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+
     "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
+
+    "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
 
     "github-api-emojis": ["github-api-emojis@1.0.4", "", {}, "sha512-KOIHyYLdixrDCGTn2j4P+q0RVxOEhKMGUiqKZmCL+c6/yjIqpCkNitcubxq0H5oOt/I9ZeBrv3zOvjT8st/rKg=="],
 
@@ -1319,6 +1702,10 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "grammex": ["grammex@3.1.13", "", {}, "sha512-LnPnhOBLEJEVKS8WFDVaA397L9Kq55Q9oSITJiVLHVdhAclfUkWzQv74KhvZHKL2Q09Pb1XdsrOsZ4LfTFFTEg=="],
+
+    "graphmatch": ["graphmatch@1.1.1", "", {}, "sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg=="],
+
     "gzip-size": ["gzip-size@6.0.0", "", { "dependencies": { "duplexer": "^0.1.2" } }, "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
@@ -1333,6 +1720,8 @@
 
     "hls.js": ["hls.js@1.6.15", "", {}, "sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA=="],
 
+    "hono": ["hono@4.11.4", "", {}, "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA=="],
+
     "html-encoder-decoder": ["html-encoder-decoder@1.3.11", "", { "dependencies": { "he": "^1.1.0", "iterate-object": "^1.3.2", "regex-escape": "^3.4.2" } }, "sha512-bDRaOgwtv7trc7YsBoMOPqaFSmI11iPilcPXE1i/blBHe42z8dXQ7yw2Sh9KdmE3CF4fQcIXih69zuFmZi8HoA=="],
 
     "html-entities": ["html-entities@1.4.0", "", {}, "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA=="],
@@ -1342,6 +1731,12 @@
     "htmled": ["htmled@1.0.1", "", {}, "sha512-GfE2GsFY8rpmwdn5PQutIDwel5yeTBdlvKn6mQRSBWzyAgx946UT5K/qD9Fq8Ei5Cw4rqES8TRfSFYbxq+/CDw=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "http-status-codes": ["http-status-codes@2.3.0", "", {}, "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "human-id": ["human-id@4.1.3", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q=="],
 
@@ -1357,7 +1752,15 @@
 
     "imsc": ["imsc@1.1.5", "", { "dependencies": { "sax": "1.2.1" } }, "sha512-V8je+CGkcvGhgl2C1GlhqFFiUOIEdwXbXLiu1Fcubvvbo+g9inauqT3l0pNYXGoLPBj3jxtZz9t+wCopMkwadQ=="],
 
+    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ink": ["ink@6.8.0", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.2.4", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.6.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^5.1.1", "code-excerpt": "^4.0.0", "es-toolkit": "^1.39.10", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^8.0.0", "stack-utils": "^2.0.6", "string-width": "^8.1.1", "terminal-size": "^4.0.1", "type-fest": "^5.4.1", "widest-line": "^6.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.0.0", "react": ">=19.0.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA=="],
+
+    "ioredis": ["ioredis@5.11.1", "", { "dependencies": { "@ioredis/commands": "1.10.0", "cluster-key-slot": "1.1.1", "debug": "4.4.3", "denque": "2.1.0", "redis-errors": "1.2.0", "redis-parser": "3.0.0", "standard-as-callback": "2.1.0" } }, "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A=="],
+
+    "ip-address": ["ip-address@10.5.0", "", {}, "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
@@ -1373,9 +1776,13 @@
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
     "is-function": ["is-function@1.0.2", "", {}, "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
@@ -1383,7 +1790,11 @@
 
     "is-subdir": ["is-subdir@1.2.0", "", { "dependencies": { "better-path-resolve": "1.0.0" } }, "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw=="],
 
+    "is-unsafe": ["is-unsafe@2.0.0", "", {}, "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA=="],
+
     "is-windows": ["is-windows@1.0.2", "", {}, "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="],
+
+    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
     "isbot": ["isbot@5.1.35", "", {}, "sha512-waFfC72ZNfwLLuJ2iLaoVaqcNo+CAaLR7xCpAn0Y5WfGzkNHv7ZN39Vbi1y+kb+Zs46XHOX3tZNExroFUPX+Kg=="],
 
@@ -1395,6 +1806,8 @@
 
     "jquery": ["jquery@3.7.1", "", {}, "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="],
 
+    "js-base64": ["js-base64@3.9.2", "", {}, "sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
@@ -1403,13 +1816,27 @@
 
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
+    "json-with-bigint": ["json-with-bigint@3.5.10", "", {}, "sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w=="],
+
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsondiffpatch": ["jsondiffpatch@0.6.0", "", { "dependencies": { "@types/diff-match-patch": "^1.0.36", "chalk": "^5.3.0", "diff-match-patch": "^1.0.5" }, "bin": { "jsondiffpatch": "bin/jsondiffpatch.js" } }, "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ=="],
 
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
-    "lie": ["lie@3.1.1", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw=="],
+    "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
+
+    "libsodium": ["libsodium@0.8.4", "", {}, "sha512-lMcYaRi0zcs7tarATsQUYC7rstliIXZuoq0c6zXSgNtSNtdvBgkSegjWhpMJAXzKX3SUSwIp7+zEsob+j3LuRw=="],
+
+    "libsodium-wrappers": ["libsodium-wrappers@0.8.4", "", { "dependencies": { "libsodium": "^0.8.0" } }, "sha512-mu8aAWucZjTB5O/BtGXtW4e1agy7uHxNYG7zPthmmD1jU43LCDmSWZLN4JhflbdPXj3yDO4lxM1O9hLDgIOXDw=="],
+
+    "libsql": ["libsql@0.5.29", "", { "dependencies": { "@neon-rs/load": "^0.0.4", "detect-libc": "2.0.2" }, "optionalDependencies": { "@libsql/darwin-arm64": "0.5.29", "@libsql/darwin-x64": "0.5.29", "@libsql/linux-arm-gnueabihf": "0.5.29", "@libsql/linux-arm-musleabihf": "0.5.29", "@libsql/linux-arm64-gnu": "0.5.29", "@libsql/linux-arm64-musl": "0.5.29", "@libsql/linux-x64-gnu": "0.5.29", "@libsql/linux-x64-musl": "0.5.29", "@libsql/win32-x64-msvc": "0.5.29" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "arm", "x64", "arm64", ] }, "sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg=="],
+
+    "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
     "lightningcss": ["lightningcss@1.31.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.31.1", "lightningcss-darwin-arm64": "1.31.1", "lightningcss-darwin-x64": "1.31.1", "lightningcss-freebsd-x64": "1.31.1", "lightningcss-linux-arm-gnueabihf": "1.31.1", "lightningcss-linux-arm64-gnu": "1.31.1", "lightningcss-linux-arm64-musl": "1.31.1", "lightningcss-linux-x64-gnu": "1.31.1", "lightningcss-linux-x64-musl": "1.31.1", "lightningcss-win32-arm64-msvc": "1.31.1", "lightningcss-win32-x64-msvc": "1.31.1" } }, "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ=="],
 
@@ -1489,13 +1916,17 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+    "mime": ["mime@4.1.0", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw=="],
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
     "min-document": ["min-document@2.19.2", "", { "dependencies": { "dom-walk": "^0.1.0" } }, "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A=="],
+
+    "miniflare": ["miniflare@5.20260801.1-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260801.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-BHPVzIDA6mbx7LefxpvkXW7DHx9FKB9GorZatbnrrFTt3CVMU8zuUpbgyCuebwDKcTTOZos43ta8GQ0eMVEpxA=="],
 
     "minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
@@ -1517,11 +1948,9 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "msgpackr": ["msgpackr@1.11.9", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw=="],
+    "msgpackr": ["msgpackr@2.0.5", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA=="],
 
-    "msgpackr-extract": ["msgpackr-extract@3.0.3", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA=="],
-
-    "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
+    "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
 
     "mux.js": ["mux.js@7.1.0", "", { "dependencies": { "@babel/runtime": "^7.11.2", "global": "^4.4.0" }, "bin": { "muxjs-transmux": "bin/transmux.js" } }, "sha512-NTxawK/BBELJrYsZThEulyUMDVlLizKdxyAsMuzoCD1eFj97BVaA8D/CvKsKu6FOLYkFojN5CbM9h++ZTZtknA=="],
 
@@ -1530,6 +1959,8 @@
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
+
+    "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
 
     "next": ["next@15.5.12", "", { "dependencies": { "@next/env": "15.5.12", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.12", "@next/swc-darwin-x64": "15.5.12", "@next/swc-linux-arm64-gnu": "15.5.12", "@next/swc-linux-arm64-musl": "15.5.12", "@next/swc-linux-x64-gnu": "15.5.12", "@next/swc-linux-x64-musl": "15.5.12", "@next/swc-win32-arm64-msvc": "15.5.12", "@next/swc-win32-x64-msvc": "15.5.12", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-Fi/wQ4Etlrn60rz78bebG1i1SR20QxvV8tVp6iJspjLUSHcZoeUXCt+vmWoEcza85ElZzExK/jJ/F6SvtGktjA=="],
 
@@ -1563,6 +1994,10 @@
 
     "on-headers": ["on-headers@1.1.0", "", {}, "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A=="],
 
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
     "openai": ["openai@4.104.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" }, "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA=="],
 
     "openapi-fetch": ["openapi-fetch@0.13.8", "", { "dependencies": { "openapi-typescript-helpers": "^0.0.15" } }, "sha512-yJ4QKRyNxE44baQ9mY5+r/kAzZ8yXMemtNAOFwOzRXJscdjSxxzWSNlyBAr+o5JjkUw9Lc3W7OIoca0cY3PYnQ=="],
@@ -1591,33 +2026,45 @@
 
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
+    "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
+
+    "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
+
     "package-manager-detector": ["package-manager-detector@0.2.11", "", { "dependencies": { "quansync": "^0.2.7" } }, "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ=="],
+
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
     "parsemarkjs": ["parsemarkjs@1.0.1", "", {}, "sha512-7q9JNgiXGlMTr/CmBsNnW4+AmDSC+682izfsrIm4bm56NIv6PnynWy0U/8QIvWgsojqdIMcTbrcHvLUPhhl5FA=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
+    "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
+
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-expression-matcher": ["path-expression-matcher@1.6.2", "", {}, "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
-    "path-to-regexp": ["path-to-regexp@0.1.12", "", {}, "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="],
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
-    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
     "perfect-scrollbar": ["perfect-scrollbar@1.5.6", "", {}, "sha512-rixgxw3SxyJbCaSpo1n35A/fwI1r2rdwMKOTCg/AcG+xOEyZcE8UHVjpZMFCVImzsFoCZeJTT+M/rdEIQYO2nw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
@@ -1650,6 +2097,14 @@
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
+
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
+    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
+    "promise-limit": ["promise-limit@2.7.0", "", {}, "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw=="],
+
+    "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
     "prosemirror-changeset": ["prosemirror-changeset@2.4.0", "", { "dependencies": { "prosemirror-transform": "^1.0.0" } }, "sha512-LvqH2v7Q2SF6yxatuPP2e8vSUKS/L+xAU7dPDC4RMyHMhZoGDfBC74mYuyYF4gLqOEG758wajtyhNnsTkuhvng=="],
 
@@ -1689,9 +2144,15 @@
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
+    "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
-    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "qs": ["qs@6.14.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q=="],
 
@@ -1711,6 +2172,8 @@
 
     "react-hook-form": ["react-hook-form@7.71.2", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA=="],
 
+    "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
+
     "react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
@@ -1727,7 +2190,13 @@
 
     "read-yaml-file": ["read-yaml-file@1.1.0", "", { "dependencies": { "graceful-fs": "^4.1.5", "js-yaml": "^3.6.1", "pify": "^4.0.1", "strip-bom": "^3.0.0" } }, "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA=="],
 
+    "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
+
+    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
 
     "regenerate": ["regenerate@1.4.2", "", {}, "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="],
 
@@ -1739,11 +2208,17 @@
 
     "regex-escape": ["regex-escape@3.4.11", "", {}, "sha512-051l4Hl/0HoJwTvNztrWVjoxLiseSfCrDgWqwR1cnGM/nyQSeIjmvti5zZ7HzOmsXDPaJ2k0iFxQ6/WNpJD5wQ=="],
 
+    "regexp-to-ast": ["regexp-to-ast@0.5.0", "", {}, "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="],
+
     "regexpu-core": ["regexpu-core@6.4.0", "", { "dependencies": { "regenerate": "^1.4.2", "regenerate-unicode-properties": "^10.2.2", "regjsgen": "^0.8.0", "regjsparser": "^0.13.0", "unicode-match-property-ecmascript": "^2.0.0", "unicode-match-property-value-ecmascript": "^2.2.1" } }, "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA=="],
 
     "regjsgen": ["regjsgen@0.8.0", "", {}, "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q=="],
 
     "regjsparser": ["regjsparser@0.13.0", "", { "dependencies": { "jsesc": "~3.1.0" }, "bin": { "regjsparser": "bin/parser" } }, "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q=="],
+
+    "remeda": ["remeda@2.33.4", "", {}, "sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
@@ -1751,7 +2226,13 @@
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
+    "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
+
+    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
 
     "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
 
@@ -1783,9 +2264,11 @@
 
     "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
+    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
+
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
-    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+    "sharp": ["sharp@0.35.2", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.4" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.2", "@img/sharp-darwin-x64": "0.35.2", "@img/sharp-freebsd-wasm32": "0.35.2", "@img/sharp-libvips-darwin-arm64": "1.3.1", "@img/sharp-libvips-darwin-x64": "1.3.1", "@img/sharp-libvips-linux-arm": "1.3.1", "@img/sharp-libvips-linux-arm64": "1.3.1", "@img/sharp-libvips-linux-ppc64": "1.3.1", "@img/sharp-libvips-linux-riscv64": "1.3.1", "@img/sharp-libvips-linux-s390x": "1.3.1", "@img/sharp-libvips-linux-x64": "1.3.1", "@img/sharp-libvips-linuxmusl-arm64": "1.3.1", "@img/sharp-libvips-linuxmusl-x64": "1.3.1", "@img/sharp-linux-arm": "0.35.2", "@img/sharp-linux-arm64": "0.35.2", "@img/sharp-linux-ppc64": "0.35.2", "@img/sharp-linux-riscv64": "0.35.2", "@img/sharp-linux-s390x": "0.35.2", "@img/sharp-linux-x64": "0.35.2", "@img/sharp-linuxmusl-arm64": "0.35.2", "@img/sharp-linuxmusl-x64": "0.35.2", "@img/sharp-webcontainers-wasm32": "0.35.2", "@img/sharp-win32-arm64": "0.35.2", "@img/sharp-win32-ia32": "0.35.2", "@img/sharp-win32-x64": "0.35.2" } }, "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -1815,7 +2298,17 @@
 
     "sirv": ["sirv@2.0.4", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ=="],
 
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+
+    "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
+
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
     "sopplayer": ["sopplayer@1.0.0", "", {}, "sha512-lgbWHqQdbsAy7WEEWyi6ciYaPXCa80pprTZxIRN5pdm3OSZBnC2GacNwZ4allmw7AcwHgcyO+D7uPKhwsLiIQQ=="],
 
@@ -1829,7 +2322,11 @@
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
+    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
@@ -1837,21 +2334,33 @@
 
     "steamlit": ["steamlit@1.0.0", "", {}, "sha512-HrUNAseHT82W/8OCL1wAAwPlpDglGbdWmKn27Aejc7QFh9JZGn6OTulLSTKw179FOwX5MQTWy+yl8nZUqVjEww=="],
 
+    "streamx": ["streamx@2.28.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw=="],
+
+    "string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
+
+    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
+    "strnum": ["strnum@2.4.1", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg=="],
+
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
+
+    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
     "swr": ["swr@2.4.1", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA=="],
 
     "systemjs": ["systemjs@6.15.1", "", {}, "sha512-Nk8c4lXvMB98MtbmjX7JwJRgJOL8fluecYCfCeYBznwmpOs8Bf15hLM6z4z71EDAhQVrQrI+wt1aLWSXZq+hXA=="],
+
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
     "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 
@@ -1863,11 +2372,21 @@
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
+    "tar-fs": ["tar-fs@3.1.3", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ=="],
+
+    "tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
+
+    "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg=="],
+
     "terabox": ["terabox@1.0.0", "", {}, "sha512-SCqf1fVF/cHfW4MkvcUP7vN7i1YikmyaVNWin/fOJdFzhJmQ16tcQjsJaHQ7X5pizGVkX5ZorlDZPriLqxFHmg=="],
 
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 
+    "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
+
     "terser": ["terser@5.46.0", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": { "terser": "bin/terser" } }, "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg=="],
+
+    "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
@@ -1917,6 +2436,8 @@
 
     "turbo-windows-arm64": ["turbo-windows-arm64@2.8.13", "", { "os": "win32", "cpu": "arm64" }, "sha512-R819HShLIT0Wj6zWVnIsYvSNtRNj1q9VIyaUz0P24SMcLCbQZIm1sV09F4SDbg+KCCumqD2lcaR2UViQ8SnUJA=="],
 
+    "type-fest": ["type-fest@5.8.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA=="],
+
     "type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -1925,7 +2446,11 @@
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
+    "undici": ["undici@8.10.0", "", {}, "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ=="],
+
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
     "unicode-canonical-property-names-ecmascript": ["unicode-canonical-property-names-ecmascript@2.0.1", "", {}, "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg=="],
 
@@ -1934,6 +2459,8 @@
     "unicode-match-property-value-ecmascript": ["unicode-match-property-value-ecmascript@2.2.1", "", {}, "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg=="],
 
     "unicode-property-aliases-ecmascript": ["unicode-property-aliases-ecmascript@2.2.0", "", {}, "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ=="],
+
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
@@ -1950,6 +2477,8 @@
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
+
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
     "valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
 
@@ -1991,11 +2520,39 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
-    "ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+    "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
+
+    "workerd": ["workerd@1.20260801.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260801.1", "@cloudflare/workerd-darwin-arm64": "1.20260801.1", "@cloudflare/workerd-linux-64": "1.20260801.1", "@cloudflare/workerd-linux-arm64": "1.20260801.1", "@cloudflare/workerd-windows-64": "1.20260801.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-/g9JGTyqnHtoIscpBHqKD8swE2V4StBs2i69PmLiOhH45OP95jCFICl4F1hKlgN57rqfni5LiCitttoX5OOkVA=="],
+
+    "wrangler": ["wrangler@4.120.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260801.1-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260801.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260801.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-cBmu/MeaB/fPacC0JpATs4duTOCagBxrZo+vBzuTX06tLzwSyAHE1drlHUZ8rP0VqVz1fy3ReGYTiHdKkoHltg=="],
+
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+
+    "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
+
+    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
+
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+
+    "zeptomatch": ["zeptomatch@2.1.0", "", { "dependencies": { "grammex": "^3.1.11", "graphmatch": "^1.1.0" } }, "sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -2014,6 +2571,24 @@
     "@changesets/apply-release-plan/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
     "@changesets/write/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
+
+    "@chevrotain/cst-dts-gen/lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
+
+    "@chevrotain/gast/lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
+
+    "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "@distilled.cloud/cloudflare-runtime/workerd": ["workerd@1.20260704.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260704.1", "@cloudflare/workerd-darwin-arm64": "1.20260704.1", "@cloudflare/workerd-linux-64": "1.20260704.1", "@cloudflare/workerd-linux-arm64": "1.20260704.1", "@cloudflare/workerd-windows-64": "1.20260704.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-GDZ0jzIYDYfN7rCt/oFJv4BG3QJ+4IS2kfRvxEMY9VKIfPhzo63PH69Ir7ug8LfORCgCtmfkiQVXrqbot7pZTQ=="],
+
+    "@effect/vitest/vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
+
+    "@img/sharp-freebsd-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.2", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw=="],
+
+    "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+
+    "@img/sharp-webcontainers-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.2", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
@@ -2041,6 +2616,18 @@
 
     "@monoweb/server/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
+    "@mrleebo/prisma-ast/lilconfig": ["lilconfig@2.1.0", "", {}, "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="],
+
+    "@octokit/plugin-paginate-rest/@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
+    "@octokit/plugin-rest-endpoint-methods/@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
+    "@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "@parcel/watcher/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "@puppeteer/browsers/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
     "@radix-ui/react-alert-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-avatar/@radix-ui/react-context": ["@radix-ui/react-context@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw=="],
@@ -2065,6 +2652,8 @@
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
+    "@react-router/dev/pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
     "@tailwindcss/node/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
@@ -2083,11 +2672,9 @@
 
     "@vitejs/plugin-legacy/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
-    "@vitest/runner/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
-    "@vitest/snapshot/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
     "accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+
+    "alchemy/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -2099,6 +2686,12 @@
 
     "body-parser/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
+    "chevrotain/lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
+
+    "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
     "compression/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "dashjs/fast-deep-equal": ["fast-deep-equal@2.0.1", "", {}, "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="],
@@ -2107,9 +2700,17 @@
 
     "express/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "express/path-to-regexp": ["path-to-regexp@0.1.12", "", {}, "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="],
+
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "ink/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "libsql/detect-libc": ["detect-libc@2.0.2", "", {}, "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="],
+
+    "localforage/lie": ["lie@3.1.1", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw=="],
 
     "lowlight/highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
@@ -2121,11 +2722,15 @@
 
     "mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
+    "miniflare/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+
     "morgan/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "morgan/on-finished": ["on-finished@2.3.0", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "next/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "niva-ui/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
@@ -2139,9 +2744,13 @@
 
     "p-filter/p-map": ["p-map@2.1.0", "", {}, "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="],
 
-    "pkg-types/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "proper-lockfile/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "prosemirror-trailing-node/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "raw-body/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
@@ -2149,33 +2758,143 @@
 
     "read-yaml-file/pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
+    "readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
     "regjsparser/jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "restore-cursor/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "sanskrit-lang/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "send/mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+
+    "sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
     "showdown/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 
     "showdown-target-blank/showdown": ["showdown@1.1.0", "", {}, "sha512-qg3WJ40tVdXoEnccka5R+denlJyb+0iv24z6v99y2G7Ew5mrskYUrR7YYqf3Z3dV/4bZbNWcCJhAas7u1vKMTA=="],
+
+    "string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
+    "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
     "tsx/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
-    "vite-node/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+    "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "vite/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "vite-plugin-static-copy/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "vite-plugin-static-copy/fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
 
-    "vitest/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+    "vitest/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "vitest/tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
 
     "webpack-bundle-analyzer/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "webpack-bundle-analyzer/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "webpack-bundle-analyzer/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
+    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@distilled.cloud/cloudflare-runtime/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@distilled.cloud/cloudflare-runtime/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260704.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-XO+vvdhhTNZSsIWCkZ+JaE/JrFUmQAB0H0y/sVkAf32xa2TYBRvFUMwjSqf6WxtlxcKPQvmbLfpO/UQ0l/q4eQ=="],
+
+    "@distilled.cloud/cloudflare-runtime/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260704.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6iI7nbOOO8PzEQ6UZVBZB/hv95m8jl0yvyjMuWrF5cJbiLb5zPw3KnpqvGi+aeOs2ZmUkc81i1FWKfXwLXzPRA=="],
+
+    "@distilled.cloud/cloudflare-runtime/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260704.1", "", { "os": "linux", "cpu": "x64" }, "sha512-3mT0YHtxT7eLjghu3hKSJDUQoz+AYv8FM43nLPYhM0YiHOxr8OlmvnCb2Lp7v/U3bwd3Gnx7WEqjSppR583mGg=="],
+
+    "@distilled.cloud/cloudflare-runtime/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260704.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Opo7cPTPg4x0WwK+eZSDszCyFLKQkOGNCWxF005HRTJ5SJH8h0K9KyrC1k4LBwx3haXSVi+E1eGqo1gZ1Hmhkg=="],
+
+    "@distilled.cloud/cloudflare-runtime/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260704.1", "", { "os": "win32", "cpu": "x64" }, "sha512-a97Ecnzhy04x3U052VKPCNp863F7Wf00WY7Ga5P0SbtYvaO1PDzylsHrvFMPKeiDFcOwqiredawmJ+v6bhIgeQ=="],
+
+    "@effect/vitest/vitest/@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
+
+    "@effect/vitest/vitest/@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
+
+    "@effect/vitest/vitest/@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
+
+    "@effect/vitest/vitest/@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
+
+    "@effect/vitest/vitest/@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
+
+    "@effect/vitest/vitest/@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
+
+    "@effect/vitest/vitest/@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
+
+    "@effect/vitest/vitest/es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
+
+    "@effect/vitest/vitest/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "@effect/vitest/vitest/std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
+
+    "@effect/vitest/vitest/tinyexec": ["tinyexec@1.3.0", "", {}, "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ=="],
+
+    "@effect/vitest/vitest/tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
+
+    "@img/sharp-freebsd-wasm32/@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
+
+    "@img/sharp-webcontainers-wasm32/@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 
     "@monoweb/homepage/react-dom/scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
@@ -2184,6 +2903,10 @@
     "@monoweb/homepage/tailwindcss/postcss-import": ["postcss-import@15.1.0", "", { "dependencies": { "postcss-value-parser": "^4.0.0", "read-cache": "^1.0.0", "resolve": "^1.1.7" }, "peerDependencies": { "postcss": "^8.0.0" } }, "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew=="],
 
     "@monoweb/server/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "@octokit/plugin-paginate-rest/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+
+    "@octokit/plugin-rest-endpoint-methods/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
 
     "@vektorprogrammet/sdk/vitest/@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
 
@@ -2201,7 +2924,7 @@
 
     "@vektorprogrammet/sdk/vitest/es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
 
-    "@vektorprogrammet/sdk/vitest/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+    "@vektorprogrammet/sdk/vitest/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "@vektorprogrammet/sdk/vitest/std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
@@ -2213,6 +2936,12 @@
 
     "body-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
+    "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "cliui/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "compression/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "express/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
@@ -2223,6 +2952,52 @@
 
     "morgan/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
+    "next/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "next/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "next/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "next/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "next/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "next/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "next/sharp/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "next/sharp/@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "next/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "next/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "next/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "next/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "next/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "next/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "next/sharp/@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "next/sharp/@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "next/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "next/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "next/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "next/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "next/sharp/@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "next/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "next/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
     "notion-design-system/lucide-react/react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
     "openai/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
@@ -2230,6 +3005,8 @@
     "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
@@ -2290,6 +3067,66 @@
     "vite-plugin-static-copy/fs-extra/jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
     "vite-plugin-static-copy/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
+    "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "@effect/vitest/vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "@monoweb/homepage/tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/design-specs/0003-effect-v4-receipt-sdk-compatibility.md
+++ b/design-specs/0003-effect-v4-receipt-sdk-compatibility.md
@@ -1,0 +1,365 @@
+# Live design spec 0003 — Effect v4 Receipt SDK compatibility
+
+> **Summary:** One SDK-only maintainer journey that migrates the real `mono-web/packages/sdk` implementation to the exact Effect `4.0.0-beta.107` boundary and proves an authenticated, deterministic Receipt trace. It preserves both existing SDK entrypoints and domain verbs, fails closed before transport when configuration is absent or invalid, proves strict Hydra/Receipt decoding, preserves typed HTTP/network errors, and proves Effect interruption aborts the underlying fetch. This is not a disposable shipped probe, a backend/consumer migration, a route cutover, or a production-success claim.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| Stable ID | `0003` |
+| Status | `accepted` — product lead accepted after independent review on `2026-08-10` |
+| Owner | SDK platform lane / future bounded writer |
+| Intended implementation lane | Stage-1 SDK platform — Effect v4 compatibility and Receipt tracer |
+| Created | `2026-08-10` |
+| Base checkpoint | `12c1f3ea6ab1b29d760ed60853c90e46e1aa466d` (`mono-web` canonical main checkpoint) |
+| Journey count | One maintainer journey; one future implementation PR |
+
+This accepted spec was authored from a separate manual worktree. It has no implementation, install, build, test, provider, publication, or consumer evidence. Implementation has not started. Status records independent review and explicit product-lead acceptance under the lifecycle; the product lead remains read-only to production code.
+
+## Goal, constraints, and values
+
+### Goal
+
+Give an SDK maintainer a repeatable, local, no-backend journey that changes the actual SDK implementation from Effect 3 to exact Effect `4.0.0-beta.107` while preserving the current client contract. The journey must exercise the existing default Promise entrypoint (`@vektorprogrammet/sdk`, export `"."`) and Effect entrypoint (`@vektorprogrammet/sdk/effect`, export `"./effect"`) through one deterministic Receipt fixture:
+
+```text
+explicit base URL + Bearer token
+  → admin.receipts.list({ status: "pending", page: 1, pageSize: 2 })
+  → GET /api/admin/receipts?... with Hydra JSON
+  → strict Schema boundary
+  → current Page-compatible value + AdminReceipt values + Date fields
+  → admin.receipts.approve(id)
+  → PUT /api/admin/receipts/{id}/status { status: "refunded" }
+  → 204
+  → void
+```
+
+The same tracer also demonstrates the fail-closed configuration boundary, malformed-input rejection, existing typed error mapping, and cancellation ownership. It proves SDK behavior against a local fixture only; it does not prove that Symfony, a future Worker, MySQL, a route, an app, or production accepts the request.
+
+### Constraints
+
+- **Exact beta boundary.** The implementation MUST pin `effect` to the exact version `4.0.0-beta.107`, not `^4`, `beta`, `latest`, a snapshot, or a copied source signature. The official npm registry metadata observed on `2026-08-10` reports the `beta` dist-tag as `4.0.0-beta.107` and `latest` as stable `3.22.1`. The capability reference observed upstream `main` at beta.106 on the same date; that older observation is stale for this lane and is not permission to use beta.106.
+- **Fresh source/signature gate.** At implementation start, re-fetch the official registry manifest and official package source/types for the pinned beta before editing SDK code. Verify the package name/version, tarball integrity, shasum, registry signatures, and provenance/attestation; inspect the installed source for every v4 API signature used by the implementation. In particular, verify the exact `Effect.tryPromise`/`Effect.promise` `AbortSignal` contract, Schema decoding entrypoint, Effect runtime/fork/interruption APIs, and any Scope/resource API actually used. Do not copy signatures from this spec or from the beta.106 capability report. If the dist-tag, manifest, signature, integrity, provenance, or inspected source differs from the pinned evidence, stop and enter `Drift` before mutation.
+- **No hidden Promise cancellation.** The Effect transport MUST pass the signal supplied by the verified v4 async constructor into `fetch`. A Promise wrapper MAY call `Effect.runPromise` only at the existing default public boundary. It MUST NOT turn the Effect client into a Promise or abandon an underlying fetch when a fiber is interrupted.
+- **Existing public seam.** Preserve the package export map, `createClient(baseUrl, options?)` and `createEffectClient(baseUrl, options?)` call shapes, `ClientOptions.auth` static/async behavior, namespaces, public `SdkError` classes, Schema-inferred domain values, `ClientContext`, and existing Receipt verbs (`list`, `approve`, `reject`, `reopen`, plus the non-admin Receipt methods). The additive `ConfigurationError`/`SdkErrorType` `"configuration"` safety error is the sole new public error; it is not a public API redesign.
+- **Explicit configuration contract.** `apiUrl` remains exported as `string | undefined`; absent `API_URL`/`VITE_API_URL` evaluates to `undefined` without a module-evaluation throw or fallback. `createClient(baseUrl: string | undefined, options?)` and `createEffectClient(baseUrl: string | undefined, options?)` accept an absent base without synchronously throwing, and every verb remains Promise- or Effect-shaped. Missing/invalid base validation runs inside the effectful transport path: Promise verbs reject `ConfigurationError` (`SdkErrorType` `"configuration"`), Effect verbs fail with internal tagged `Configuration`, and `fetch` is never called.
+- **Real SDK migration, not a shipped probe.** The tracer is a deterministic test/fixture inside the real SDK package. It is not a new package, public export, app dependency, one-off script shipped in `dist`, or disposable compatibility package. The implementation MUST keep the complete SDK source/build surface compiling; it MUST NOT narrow `tsconfig` or omit non-Receipt domains to make a Receipt test pass.
+- **Local-only evidence.** The fixture replaces `globalThis.fetch` in the SDK test process and must not open a socket, contact Symfony, contact a Worker, contact Railway, contact Cloudflare/Alchemy, use credentials, read production data, or publish anything. A fixture URL is an assertion input, not a reachable service.
+- **Path and resource isolation.** The future writer may mutate only `mono-web/packages/sdk/**` and the required root `mono-web/bun.lock` recording the exact dependency pin. `packages/sdk/openapi.json` is read-only contract evidence, not an implementation target. App manifests/lockfiles, root `package.json`, server code, provider files, route manifests, and this spec are forbidden. The root lockfile is a shared resource if another lane must refresh it; schedule that edge rather than allowing concurrent lockfile edits.
+- **No external authority.** No credentials, provider commands, deployment, remote state, route action, production data/action, publication, or remote PR is part of this journey. The writer reports any discovered external effect as `Drift` and stops.
+
+### Values
+
+- **Stable seam:** Keep client intent and public domain verbs stable while internals move from v3 to v4.
+- **Fail closed:** Missing configuration is an explicit error before transport, never an implicit production destination.
+- **Schema at the boundary:** Decode the external representation into current domain values; never cast malformed JSON or invent an empty Page.
+- **Ownership and cancellation:** Every asynchronous operation has an owner and termination path; interruption must reach the actual fetch.
+- **Evidence over implication:** A passing TypeScript build, a test-only fixture, or a deployment log proves only its named claim.
+- **Reversible and local:** The journey uses synthetic data and a disposable fetch fixture; no remote cleanup or production rollback is needed.
+- **Honest migration order:** Receipt-first SDK evidence prepares a later seam freeze. It does not claim backend parity, a route cutover, or a Receipt Worker.
+
+## Current behavior and intended behavior
+
+### Current behavior (baseline at `12c1f3e`, observed `2026-08-10`)
+
+| Area | Current contract or defect | Evidence authority |
+|---|---|---|
+| Package boundary | `packages/sdk/package.json` is `@vektorprogrammet/sdk` `0.2.0`; `"."` maps to `dist/promise` and `"./effect"` maps to `dist/effect-client`. Dependencies declare `effect` `^3.21.0`, `@effect/platform` `^0.96.0`; dev tests use Vitest and declare `@effect/vitest` `^0.29.0`. | `packages/sdk/package.json` |
+| Promise seam | `createClient(baseUrl, { auth? })` builds the domain object. Each domain method is wrapped with `Effect.runPromise` and maps `InternalSdkError` to public `SdkError` subclasses. | `packages/sdk/src/promise.ts` |
+| Effect seam | `createEffectClient(baseUrl, { auth? })` returns the same domain namespaces with Effect-returning methods and internal tagged errors. | `packages/sdk/src/effect-client.ts` |
+| Transport | `transport.ts` uses `Effect.tryPromise` around `fetch`, but calls `fetch(url, init)` without a signal. Status mapping covers 401/403, 404, 409, 422, 429, and other/network failures. JSON responses are decoded through Schema. URL construction/validation is currently synchronous and has no typed configuration error. | `packages/sdk/src/transport.ts`, `src/errors.ts` |
+| Collection boundary | `getCollection` casts `hydra:member` to an array and defaults a missing member collection to `[]` and `hydra:totalItems` to `0`. Malformed collection shape can therefore become an apparently valid empty Page. | `packages/sdk/src/transport.ts` |
+| Receipt values | `AdminReceipt` requires `id`, `visualId`, `description`, `sum`, ISO-derived `receiptDate`/`submitDate`, status, nullable `refundDate`, and `userName`. Page-compatible values carry `items`, `totalItems`, `page`, and `pageSize`; the declared admin-list return type currently omits the latter two fields even though runtime supplies them. `DateFromIso` constructs `Date` without an explicit invalid-date guard. | `packages/sdk/src/schemas/receipt.ts`, `src/schemas/common.ts`, `src/adapter/dates.ts` |
+| Receipt commands | Admin list calls `GET /api/admin/receipts` with `status`, `page`, and `itemsPerPage` query values. `approve` calls `PUT /api/admin/receipts/{id}/status` with `{ status: "refunded" }`; `reject` and `reopen` use the existing status strings. | `packages/sdk/src/domains/admin/receipts.ts` |
+| Configuration | `src/config.ts` checks `process.env.API_URL`, `import.meta.env.VITE_API_URL`, then the hard-coded `https://vektorprogrammet-production.up.railway.app`; the exported value is currently typed as `string`. | `packages/sdk/src/config.ts`; ADR 0001 §§2, 4, 14 |
+| Existing tests | Transport tests cover successful decode, 401/404/422/network tags, static Bearer auth, and per-request async auth. They do not prove strict Hydra rejection, 204 void behavior, fail-closed configuration, or interruption/abort. | `packages/sdk/src/__tests__/transport.test.ts` |
+| Repository drift | Homepage/dashboard manifests and imports still contain stale published SDK/OpenAPI consumers, and the root lockfile contains Effect 3. These downstream artifacts are not compatible evidence for this SDK-only lane. | Scout report; app manifests/imports; root `bun.lock` |
+
+### Intended behavior
+
+After a bounded writer realizes accepted intent:
+
+1. The SDK package manifest and **root `bun.lock`** resolve exactly `effect@4.0.0-beta.107`; the root lock update is required, not optional. `@effect/platform` has no v4 release and is unused, so it is removed. `@effect/vitest` has a beta.107-compatible release with current Vitest `>=4.1` but is unused, so it is removed unless a fresh source check proves it is required. No v3 Effect package is retained to mask incompatibility.
+2. Every existing SDK source module, not only Receipt modules, compiles against the verified v4 APIs. The `"."` and `"./effect"` export map stays intact, and public namespaces/domain verbs remain available with their current call/return/error shapes. `admin.receipts.list` receives an additive type correction to the existing runtime Page-compatible `{ items, totalItems, page, pageSize }` shape; runtime and call shape do not change.
+3. `apiUrl` remains exported as `string | undefined`; with both supported API URL inputs absent it is exactly `undefined`, and importing the module (including built output) does not throw or select Railway. `createClient(undefined)` and `createEffectClient(undefined)` return clients without synchronously throwing.
+4. When a Promise verb runs with an absent or invalid base, its operation rejects `ConfigurationError` with `SdkErrorType` `"configuration"`; when an Effect verb runs with that base, its operation fails with internal tagged `Configuration`. Both failures occur inside the effectful transport path before `fetch`, with zero fixture calls and no Railway URL.
+5. The Promise client sends an authenticated list request with the exact URL `https://receipt-fixture.invalid/api/admin/receipts?status=pending&page=1&itemsPerPage=2` (or an equivalent URL with only semantically equivalent encoding/order), `Accept: application/ld+json`, and `Authorization: Bearer trace-token`. The Hydra response decodes into `Page<AdminReceipt>` with one item, numeric `totalItems`, requested page/page size, and JavaScript `Date` values.
+6. The Effect client returns an actual Effect value before execution (`Effect.isEffect(...)` is true under the verified v4 source). Running it through the fixture produces the same typed `Page<AdminReceipt>` contract; it is not a Promise hidden behind a type annotation.
+7. `admin.receipts.approve(42)` sends the authenticated `PUT /api/admin/receipts/42/status` request with JSON body `{ "status": "refunded" }`. Lowercase `refunded` is the wire representation of the domain model's canonical `Pending → Refunded` transition. A fixture `204` response resolves the Promise client to `undefined`/`void` and does not attempt `response.json()`; the Effect client keeps the corresponding `Effect<void, InternalSdkError>` contract.
+8. A malformed Hydra envelope or malformed Receipt member fails at the Schema boundary with the existing typed validation surface. It never becomes an empty Page, a partially populated `AdminReceipt`, or a value passed to a consumer. The Promise surface maps the internal validation tag to `ValidationError`; the Effect surface retains the internal tagged validation error. Unparsable ISO dates are rejected by the tightened date adapter.
+9. Existing typed HTTP/network mappings remain observable for the current status/error matrix: 401/403 → `UnauthorizedError`/`Unauthorized`, 404 → `NotFoundError`/`NotFound`, 409 → `ConflictError`/`Conflict`, 422 violations → `ValidationError`/`Validation` with fields, 429 → `RateLimitedError`/`RateLimited`, other HTTP statuses → `NetworkError`/`Network`, and rejected fetch → `NetworkError`/`Network`. Missing/invalid base maps to `ConfigurationError`/`Configuration`. Static and per-request async Bearer auth remain intact.
+10. A deliberately slow, abort-aware fixture fetch receives the Effect-provided `AbortSignal`. Starting the Effect request in an owned fiber and interrupting that fiber aborts the signal, rejects/settles the fixture, leaves zero active owned request work, and produces an interruption observation rather than a successful Receipt or a Promise-only wrapper that hides a still-running fetch. No detached child fiber, timer, listener, or completion callback survives the owner.
+11. The complete SDK package build and public export checks pass. The implementation cannot pass by compiling only the Receipt tracer or by deleting/omitting unrelated domain source. No app, backend, OpenAPI, route, Cloudflare, Alchemy, publication, or consumer success claim is made.
+
+## Exact maintainer journey
+
+One SDK maintainer starts from a clean worktree at the accepted base and completes this one local journey. The future writer records sanitized command output in the one-to-one PR evidence section; this draft does not create an evidence file.
+
+### 1. Freeze the v4 source boundary before editing
+
+1. Confirm the worktree is a new manual worktree based on `12c1f3ea6ab1b29d760ed60853c90e46e1aa466d`, with no unrelated changes. Record the worktree and branch in the task handoff.
+2. With no credentials, production data, provider profile, or remote action, retrieve the official npm metadata for `effect@4.0.0-beta.107` and the current `beta`/`latest` dist-tags. Verify:
+   - package name `effect` and version `4.0.0-beta.107`;
+   - tarball `https://registry.npmjs.org/effect/-/effect-4.0.0-beta.107.tgz`;
+   - registry `dist.integrity` and `dist.shasum` match the fresh response;
+   - registry signatures and the SLSA provenance attestation are present and match the fresh response;
+   - the official package manifest has `publishConfig.provenance: true` and the expected source repository.
+3. Inspect the exact installed beta source/types before writing adapters. At minimum capture the signatures/behavior for `Effect.tryPromise`/`Effect.promise`, `Effect.isEffect`, the selected Schema decoder/transformation API, `Effect.runFork`/`Fiber.interrupt` (or the verified equivalent), and any resource/finalizer primitive. The official beta.107 source currently documents an `AbortSignal` argument for `tryPromise`; this is a source-check target, not a license to skip the fresh check.
+4. If the registry metadata or source differs, if beta.107 is unavailable, if the package manager resolves another Effect version, or if the signal/Schema/interruption contract cannot support the required journey, stop before SDK mutation and enter `Drift`. Do not substitute beta.106, stable v3, a guessed signature, a custom Promise cancellation layer, or a disposable probe package.
+
+### 2. Pin and migrate the real SDK boundary
+
+1. Change only the allowed SDK package paths and the required root lockfile. Pin `effect` exactly to `4.0.0-beta.107`; remove unused `@effect/platform` (no v4 release) and unused `@effect/vitest` (a beta.107-compatible release exists for current Vitest `>=4.1`, but the SDK tests do not use it) unless a fresh source check proves an exact compatible package is required. Do not touch app manifests or their pnpm lockfiles. Run ordinary `bun install` to refresh the required root `bun.lock`, inspect the exact beta resolution, then run `bun install --frozen-lockfile` as the reproducibility gate before build or tests.
+2. Adapt existing SDK modules to the verified v4 API without changing public names or namespaces. Keep the transport's typed status/error mapping and dynamic auth behavior. Validate an absent/invalid base inside the effectful transport path and map it to internal `Configuration`/public `ConfigurationError`; do not synchronously throw from either client factory. Use the signal-bearing v4 async constructor for every fetch, pass its signal to `fetch`, and preserve interruption rather than converting it into a normal success or silently detached rejection.
+3. Replace cast/default Hydra parsing with a strict boundary schema that requires an array `hydra:member`, validates every `AdminReceipt`, and validates any present `hydra:totalItems` as numeric. Preserve the current Page-compatible runtime fields and page parameter behavior, and correct the admin-list declaration to `Page<AdminReceipt>` without changing runtime/call shape. Do not change `packages/sdk/openapi.json`; it is a read-only Symfony contract reference.
+4. Tighten `DateFromIso` and `NullableDateFromIso` so unparsable dates (including `Invalid Date`) reject at the boundary; retain an explicit invalid-date fixture case. Remove the Railway fallback; `apiUrl` remains an exported `string | undefined` and absent env resolves to `undefined` without a module-evaluation throw. Do not add a new public factory or silently change any other public behavior.
+5. Keep the tracer in SDK tests (for example, a new `packages/sdk/src/__tests__/receipt-effect-v4-compatibility.test.ts`) and keep it local/deterministic. It must not become a shipped export, a package, or a consumer dependency.
+
+### 3. Run the deterministic Receipt tracer
+
+Use a fixture base URL such as `https://receipt-fixture.invalid` and stub `globalThis.fetch`; do not open a real network socket. The fixture must route requests by method and URL and record `RequestInit` without storing credentials or real data.
+
+1. **Public surface guard.** Construct both client entrypoints with the valid fixture URL and token. Assert the existing top-level and nested namespaces and all existing domain verbs are present. Assert the Promise method returns a Promise-like value and the Effect method returns an actual Effect value. This guard covers the complete SDK surface while the observable journey remains Receipt-first.
+2. **Direct `apiUrl` absence.** With `API_URL` and `VITE_API_URL` absent, read the exported `apiUrl` value and assert it is exactly `undefined`. Assert module evaluation does not throw, no `DEFAULT_API_URL`/Railway value exists, and the direct value assertion does not invoke `fetch`. Repeat this assertion against built output in step 9; this is a value/export check, separate from invoking a client verb.
+3. **Client-operation configuration failure.** Construct `createClient(undefined)` and `createEffectClient(undefined)` without a synchronous throw. Invoke one existing Receipt verb through each client and assert the Promise-shaped operation rejects `ConfigurationError` with `type === "configuration"` while the Effect-shaped operation fails with internal `_tag === "Configuration"`. Repeat with an invalid explicit URL. Assert zero fixture calls and no request URL equal to Railway.
+4. **Authenticated Hydra list.** Return one valid pending admin receipt for the exact list URL. Through the default Promise client, call `admin.receipts.list({ status: "pending", page: 1, pageSize: 2 })` and assert the result is typed/structurally `Page<AdminReceipt>` with `items`, `totalItems`, `page`, and `pageSize`. Assert the URL/query, `Authorization: Bearer trace-token`, response `Accept`, every `AdminReceipt` field, `status === "pending"`, positive `sum`, and `Date` instances/values for the ISO date fields. Repeat the same fixture through the Effect client and assert direct Effect construction plus the same typed result.
+5. **Approve to refunded, 204 to void.** Return a response whose status is exactly `204` and whose `json()` method throws if called. Call `admin.receipts.approve(42)` through the Promise client. Assert method, exact path, Bearer auth, JSON body `{ status: "refunded" }`, no response-body parse, and resolved `undefined`. Run the Effect command as a direct Effect as well and assert `void` success. The fixture demonstrates the client command/wire contract only; it does not claim a server-side refund.
+6. **Malformed boundary and invalid date.** Return HTTP 200 with a malformed `hydra:member` (wrong type or missing required member), a separate HTTP 200 with a member missing a required `AdminReceipt` field such as `userName`, and a separate member with an unparsable ISO date. Assert both clients fail with typed validation before any Page/AdminReceipt value is observed. A malformed collection MUST NOT default to `[]` or `0`.
+7. **Typed failure matrix.** For deterministic fixture responses, exercise 401, 403, 404, 409, 422 with a Symfony-style `violations` body, 429, and another HTTP status (for example 500). Exercise a fetch rejection (`TypeError("Failed to fetch")`) and the absent/invalid-base `Configuration` cases. Assert the existing Promise error classes plus `ConfigurationError`, the corresponding `SdkErrorType` values, and the corresponding Effect internal tags/fields. Assert an async auth function is evaluated per request and its Bearer value is never logged or persisted.
+8. **Interruption and release.** Install a slow fixture fetch that records the received signal, increments `activeRequests`, and waits for abort; on abort it decrements `activeRequests`, records the abort, and rejects with an abort error without scheduling completion. Run the Effect list request in one owned fiber, wait until fetch has started, interrupt that fiber using the verified v4 API, and await owner termination. Assert `signal.aborted`, one abort observation, `activeRequests === 0`, no completion/Receipt result, no owned fiber/timer/listener remains, and an interruption cause/outcome rather than a successful value. If the implementation only abandons the Effect while the fixture remains active, this step fails.
+9. **Package-wide build/export proof.** The ordinary `bun install` and subsequent `bun install --frozen-lockfile` from step 1 must have completed before these commands:
+
+   ```sh
+   bun --cwd=packages/sdk run build
+   bun --cwd=packages/sdk run test
+   ```
+
+   These commands MUST compile and test every SDK source module, not a Receipt-only compiler or filtered test. Verify the package export map still resolves `"."` and `"./effect"`, declarations include the existing public names, the public surface guard passes, and built output exports `apiUrl === undefined` without module-evaluation throw when both API URL env inputs are absent. Do not claim the stale homepage/dashboard/server builds pass; their manifests/imports are a separate downstream lane.
+
+
+## Scope and allowed implementation paths
+
+The future bounded writer may mutate only:
+
+- `mono-web/packages/sdk/package.json`;
+- `mono-web/packages/sdk/tsconfig.json` only if the verified v4 compiler boundary requires a minimal compatible setting; it MUST NOT be narrowed to omit unrelated SDK modules.
+- `mono-web/packages/sdk/src/**`, including existing transport/config/domain/schema/error files and new or updated SDK tests under `src/__tests__/**`;
+- root `mono-web/bun.lock` (required) to record the exact `effect@4.0.0-beta.107` resolution and its verified integrity.
+
+The writer MUST NOT edit `mono-web/packages/sdk/openapi.json`; `dist/**`, caches, logs, and other generated local state are disposable and never evidence or committed source. The writer MUST NOT edit any app/server source, app manifest or pnpm lockfile, root `package.json`, `turbo.json`, workflows, docs, ADRs, domain files, provider/IaC files, route manifests, or this live spec. The root `bun.lock` is a required shared resource for this lane: the single writer owns its refresh, and any other lane touching it is serialized before mutation. No writer resolves that conflict by rebasing or overwriting the other's changes.
+
+## Non-goals
+
+This slice does **not** include:
+
+- homepage, dashboard, server, Symfony, MySQL, Hyperdrive, Worker, gateway, OpenAPI generation, app manifests, app lockfiles, stale `apiClient`/`QueryProvider` import cleanup, or raw-fetch cleanup;
+- backend or consumer migration, route cutover, route rollback, frontend build success, SSR success, browser journey success, or a claim that any real API accepts the request;
+- Cloudflare, Alchemy, Wrangler, provider accounts, provider commands, remote state, deployment, public routes, DNS, production data, production credentials, or external actions;
+- package publication, release, Changesets, version publication, remote PR opening, or public API redesign;
+- a new SDK package, compatibility probe package, shipped tracer, new public entrypoint, new transport owner, or a hidden Promise-only wrapper around the Effect path;
+- changing Receipt domain laws, implementing a Receipt Worker, selecting persistence, migrating photos, proving temporal/backend conformance, or claiming refund durability;
+- broad migration of consumers merely because their current manifests/imports are stale. Those artifacts remain separate downstream risk and cannot satisfy or block this SDK-only contract except as documented below.
+
+## Authority, domain, contract, and interface references
+
+- **Lifecycle authority:** [`docs/agentic-development-lifecycle.md`](../../docs/agentic-development-lifecycle.md) §§2, 4–6, 8–12 owns one-home authority, status/gates, one-journey specs, task capsules, disjoint resources, evidence limits, Drift, and operator boundaries. Its API/SDK evidence row proves only named SDK/transport cases; it does not prove a UI, backend, deployment, or domain journey.
+- **Program authority:** [`docs/product-lead-charter.md`](../../docs/product-lead-charter.md) §§1–5, 9–12 keeps `mono-web` canonical, the SDK as the seam, Receipt first, Effect v4 compatibility as a parallel Stage-1 platform lane, Symfony parity as the first production target, and the product lead read-only.
+- **Accepted topology authority:** [`docs/decisions/0001-cloudflare-topology-and-migration-architecture.md`](../../docs/decisions/0001-cloudflare-topology-and-migration-architecture.md) §§2, 4, 7, 9, 12, 14–15 requires explicit/fail-closed SDK base configuration, keeps Symfony/MySQL authoritative during parity, separates SDK evidence from backend/preview evidence, and forbids inferring provider/runtime success from this fixture.
+- **Domain authority:** [`docs/domain-model.md`](../../docs/domain-model.md) §2.5 Receipt machine and laws `T-REC-1`, `S-REC-1`, `S-REC-2`. The tracer uses a pending receipt and the legal approve command shape (`Pending → Refunded`) as a client-contract fixture. Lowercase wire status `refunded` is the transport representation of canonical `Refunded`; the fixture tests only that wire value. It does not prove the backend transition, photo requirement, submit-date immutability, or visual-ID uniqueness.
+- **Effect capability boundary:** [`docs/references/effect-v4-capability-evaluation.md`](../../docs/references/effect-v4-capability-evaluation.md) §§2, 7–11 recommends pinning beta APIs, inspecting official source at implementation start, using Schema as an external boundary, and requiring fiber/Scope ownership and interruption evidence. Its beta.106 observation is superseded for this lane by the fresh beta.107 registry check required above.
+- **Current SDK sources:** `packages/sdk/package.json`; `src/index.ts`; `src/promise.ts`; `src/effect-client.ts`; `src/transport.ts`; `src/config.ts`; `src/errors.ts`; `src/adapter/dates.ts`; `src/schemas/common.ts`; `src/schemas/receipt.ts`; `src/domains/receipts.ts`; `src/domains/admin/receipts.ts`; `src/__tests__/transport.test.ts`; and `packages/sdk/openapi.json` Receipt paths around `/api/admin/receipts` and `/api/admin/receipts/{id}/status`.
+- **Official v4 provenance/source inputs:** [npm dist-tags](https://registry.npmjs.org/effect), [exact beta.107 registry manifest](https://registry.npmjs.org/effect/4.0.0-beta.107), [beta.107 package manifest](https://unpkg.com/effect@4.0.0-beta.107/package.json), [official Effect v4 beta notice](https://effect.website/blog/releases/effect/40-beta/), and the exact installed source files/types selected by the implementation. Registry metadata observed for the starting checkpoint reports shasum `6f928025031c3f137c66a8a4f3f11bdc72804c83`, integrity `sha512-OoBAv8eF+yanc+C6xhgEUnWeXUSHA6ynnscYqpkAY9GSnzZWystsIjBowVqCkLpHGlnRtdIqYT3wHwpOY6JDnQ==`, two registry signatures under key ID `SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U`, and an npm SLSA attestation URL. These values MUST be freshly checked; they are not a substitute for implementation-time verification.
+
+## Dependency and resource graph
+
+```text
+accepted ADR 0001 + accepted local-preview authority
+  → this spec independently reviewed and product-lead accepted
+  → fresh beta.107 registry/signature/source check
+  → one SDK writer in an isolated worktree
+  → exact `effect@4.0.0-beta.107` + required root lock entry
+  → full packages/sdk build and tests
+  → deterministic Receipt tracer and interruption evidence
+  → stable SDK seam candidate
+  → later consumer/Receipt Worker lanes (separately specified)
+```
+
+| Graph item | Required shape | Boundary |
+|---|---|---|
+| Effect package | `effect@4.0.0-beta.107` exact, with fresh registry integrity/signature/provenance evidence | No beta range, stable v3 fallback, snapshot, or copied source. |
+| Platform dependency | `@effect/platform` has no v4 release and is unused by the current SDK; remove it. `@effect/vitest` has a beta.107-compatible release for current Vitest `>=4.1` but is unused; remove it unless fresh source proves it required. | No v3 dependency is added to mask v4 breakage. |
+| Config | `apiUrl: string | undefined`; absent env is `undefined` with no module throw/fallback. Factories accept `string | undefined`; verb execution validates inside Effect and maps `Configuration` → public `ConfigurationError`/`SdkErrorType` `"configuration"` before fetch. | No Railway fallback, sync throw, hostname inference, provider action, or production access. |
+| Transport | Signal-bearing v4 async constructor → `fetch(url, { signal, ... })` → typed status/config mapping → strict Schema decode | No uncancelled Promise, detached fiber, cast/default Hydra envelope, or public transport redesign. |
+| Promise surface | Existing `"."` export and `createClient` return shape, plus additive `ConfigurationError` | `Effect.runPromise` only at the existing public boundary; existing public errors and every verb remain Promise-shaped. |
+| Effect surface | Existing `"./effect"` export and `createEffectClient` return shape, plus internal `Configuration` | Direct Effect values and internal tagged errors; no Promise hiding or sync factory throw. |
+| Fixture | One in-process deterministic fetch fixture and synthetic payloads | No sockets, backend, provider, credentials, production data, or publication. |
+| Lockfile | Root `bun.lock` required and refreshed by ordinary `bun install`, then checked by `bun install --frozen-lockfile` | Shared lockfile custody is serialized to this lane's single writer. |
+
+### Exact fixture values
+
+The happy-path list fixture SHOULD use one member with values equivalent to:
+
+```json
+{
+  "hydra:member": [
+    {
+      "id": 42,
+      "visualId": "receipt-42",
+      "description": "Travel to course",
+      "sum": 125.5,
+      "receiptDate": "2026-08-08",
+      "submitDate": "2026-08-09T10:00:00Z",
+      "status": "pending",
+      "refundDate": null,
+      "userName": "Synthetic User"
+    }
+  ],
+  "hydra:totalItems": 1
+}
+```
+
+The fixture uses the synthetic Bearer value `trace-token` only in memory. It must not write a token or payload into logs/evidence. The approve fixture accepts only the exact path/body and returns a bodyless `204`; its response `json()` throws to catch accidental parsing.
+
+## Verification and evidence plan
+
+Every evidence item names one claim and one boundary. The future writer MUST run all applicable checks after the fresh source gate and record sanitized output in the one-to-one PR/handoff. No command in this draft has been run.
+
+| ID | Evidence/scenario | Required observation | What it proves | What it does not prove |
+|---|---|---|---|---|
+| E0 | Official metadata/source check | beta dist-tag/version, exact manifest, integrity/shasum/signatures/provenance, and inspected v4 signatures match `4.0.0-beta.107` | The writer used the intended source boundary | Future beta stability, backend behavior, or provider/runtime behavior |
+| E1 | Package manifest/lock inspection | Exact Effect pin; no v3 peer selected for SDK; required root lock contains the verified resolution and integrity | Dependency provenance and reproducibility | App lockfile compatibility or monorepo clean build |
+| E2 | Full SDK build + declaration/export check | Every SDK source module builds; `"."` and `"./effect"` resolve; current public names remain | Package-wide compilation and public seam preservation | App/SSR/backend build or runtime |
+| E3 | Promise authenticated list | Exact fixture URL/query, Bearer header, Hydra decode, `Page<AdminReceipt>`-typed Page-compatible value, AdminReceipt fields, Date values | Promise SDK observable Receipt contract | Symfony/API Platform or user UI success |
+| E4 | Effect authenticated list | `Effect.isEffect` before run; same decoded output after run | Direct Effect seam and v4 execution | Promise cancellation or backend success |
+| E5 | Promise approve 204 | PUT path/body/auth, no JSON parse, `undefined` result | Existing command/void contract | Refund persistence or transition authorization |
+| E6 | Effect approve 204 | Direct Effect<void> and successful 204 interpretation | Effect command contract | Worker/backend transition |
+| E7 | Malformed boundary + invalid date | Strict Hydra/member/date rejection before Page/AdminReceipt observation; no empty-page fallback | Boundary validation and schema/date safety | Backend serialization or domain-law conformance |
+| E8 | HTTP/network/config matrix | Existing public error classes/types and internal tags/fields for 401/403/404/409/422/429/other/network plus `ConfigurationError`/`Configuration` for missing/invalid base | Error compatibility and fail-closed operation boundary | Unlisted status semantics, retries, or app configuration |
+| E9 | Direct `apiUrl` absence + built output | Exported `apiUrl` is exactly `undefined` with absent env; source and built module evaluation do not throw/fallback and do not call fetch | Configuration value/export safety | Client verb execution (covered separately by E8) |
+| E10 | Slow interruption | Signal aborted, active count zero, no completion/owned work after owner termination | Underlying fetch cancellation and structured ownership | Process crash safety or remote cancellation |
+| E11 | Scope review | Only allowed SDK paths plus the required root lockfile changed | Capsule/resource discipline | Correctness of forbidden paths not touched in another branch |
+
+### Evidence boundary
+
+This evidence proves only the exact v4 package boundary, SDK compilation/export surface, local Promise/Effect Receipt transport behavior, schema/error behavior, fail-closed configuration, and local interruption ownership observed in the deterministic fixture. It does **not** prove:
+
+- Symfony parity, API Platform serialization, backend authorization, Receipt state persistence, `T-REC-1` execution, `S-REC-1` photo/date invariants, `S-REC-2` visual-ID uniqueness, or a future Receipt Worker;
+- homepage/dashboard buildability, app manifests/imports, SSR/browser behavior, React Router behavior, stale OpenAPI consumers, or raw-fetch removal;
+- Cloudflare/Alchemy/Wrangler resources, provider access, deployment, route ownership, public exposure, production data, or production credentials;
+- performance, availability, retries, distributed coordination, durable storage, publication, release readiness, or route rollback.
+
+## Risks, falsifiers, and definition of done
+
+### Known risks and conflicts
+
+| Risk/baseline | Treatment |
+|---|---|
+| Capability reference records beta.106 while official dist-tag now reports beta.107. | Pin beta.107 and require fresh official metadata/source/signature verification before implementation. Any mismatch enters `Drift`. |
+| Current SDK uses v3 `Schema` and Effect APIs, has no fetch signal, and uses permissive Hydra casts/defaults. | Migrate the real source at those boundaries; strict fixture cases and package-wide build are mandatory. Do not copy v3 signatures or wrap an uncancelled Promise. |
+| `@effect/platform` has no v4 release and is unused; `@effect/vitest` has a beta.107-compatible release for current Vitest `>=4.1` but is unused. | Remove both; retain either only if fresh source proves it is required and pin the exact compatible release. Never add v3 to force green. |
+| Config currently falls back to Railway and exports a `string`. | Remove the fallback; export `apiUrl: string | undefined`; absent env is `undefined` without module throw, and verb execution maps absent/invalid base to `ConfigurationError`/`Configuration` before fetch. |
+| `hydra:member` currently defaults to an empty array and `DateFromIso` does not explicitly reject invalid dates. | Require strict collection/member validation and validating date adapters; prove malformed collection, missing field, and invalid-date cases fail before consumer use. |
+| `AdminReceipt` currently requires `refundDate`, while the current OpenAPI admin-list schema omits it. | Keep the strict fixture/schema in this SDK contract, record the mismatch as a backend-parity risk, and require the seam-freeze/consumer successor to reconcile it. This fixture-only lane makes no server claim. |
+| Existing apps use stale SDK/OpenAPI imports and published SDK versions. | Keep them unchanged; they cannot satisfy or block this SDK-only contract. A later consumer lane owns reconciliation. |
+| Root `bun.lock` is required and a possible shared mutable resource. | The single writer owns ordinary refresh plus frozen verification; serialize any sibling lane before lockfile mutation. Never overwrite a sibling lane. |
+
+### Falsifiers
+
+Any of the following fails this slice, even if the happy-path list test passes:
+
+- beta.106, stable v3, a range, snapshot, unverified tarball, mismatched integrity/signature/provenance, or a copied/guessed v4 signature is used;
+- the implementation proceeds after an official-source/signature mismatch without entering `Drift`;
+- any SDK module is excluded, `tsconfig` is narrowed, or the full SDK build/public export map is broken to make the Receipt tracer pass;
+- `createClient`/`createEffectClient`, `"."`/`"./effect"`, namespaces, public error classes (including additive `ConfigurationError`), or Receipt verbs silently disappear or change shape;
+- `apiUrl` is anything other than `undefined` when both API URL env inputs are absent, module evaluation throws, or the built-output assertion differs from the source assertion;
+- factories synchronously throw for an absent/invalid base, a Promise verb fails to reject `ConfigurationError`/`type === "configuration"`, an Effect verb fails to return an Effect or fails with internal `_tag === "Configuration"`, or any such operation calls `fetch`/Railway;
+- missing/invalid configuration normalizes to a production URL, hostname, or any actual external request;
+- a list request loses the Bearer header, query values, ISO-to-Date decoding, Page fields, or required `AdminReceipt` fields;
+- malformed Hydra/member data or an unparsable date is accepted, defaulted to an empty Page, cast, or exposed before validation;
+- 204 command handling calls `response.json()` or resolves to a fabricated body/value instead of `void`;
+- any required HTTP/network/config case maps to the wrong existing typed error/tag or loses validation fields;
+- the Effect client returns a Promise, or interruption only abandons the Effect while the underlying fixture fetch remains active;
+- the abort signal is not passed to fetch, the active request count remains nonzero, a completion callback fires after interruption, or a child/timer/listener survives its owner;
+- a real backend/provider/production/credential/publication/route action occurs, or an app/backend/OpenAPI/raw-fetch file changes;
+- evidence claims backend, UI, deployment, domain, or production success from the local fixture;
+- unrelated paths or another lane's lockfile changes are included.
+
+### Definition of done
+
+Done means all of the following are objectively recorded by the future implementation PR:
+
+1. Fresh official beta.107 metadata, signature, integrity, provenance, and exact source/type checks pass before SDK mutation.
+2. `effect@4.0.0-beta.107` is exact in the SDK package and the required root lockfile; no v3 package is retained merely to mask the migration.
+3. The full `packages/sdk` build succeeds and its existing `"."`/`"./effect"` exports, public names, namespaces, and domain verbs remain available; built `apiUrl` is `undefined` without absent-env module throw/fallback.
+4. The one deterministic tracer passes direct apiUrl absence, client-operation configuration failure, authenticated Hydra list/Page<AdminReceipt>/Date decoding, approve→refunded 204→void, malformed boundary and invalid-date rejection, existing HTTP/network error mapping, and Effect interruption/abort/release scenarios.
+5. Evidence records exact fixture URL/query/headers/body/statuses, sanitized output, no external network/provider/production action, and the boundaries/limitations above.
+6. The path review shows only `packages/sdk/**` plus the required root `bun.lock` change; no app, backend, OpenAPI, provider, publication, or route mutation occurred.
+7. No unresolved Drift linked to this spec, its accepted dependencies, or its shared lockfile remains. The feature lead freezes the spec only after the complete journey works; independent blind-first verification follows before any release gate.
+## Rollout and rollback plan
+### No-rollout plan
+
+This lane produces local SDK evidence only. It does not publish the package, migrate consumers, change app manifests, freeze the SDK seam, cut over a route, or deploy a backend. A later seam-freeze/consumer successor owns explicit rollout planning, consumer reconciliation, side-by-side evidence, operator authority, and any reversible route decision. Until that successor is accepted, the canonical v3 SDK/Symfony line remains the behavioral reference; this spec cannot be used as rollout approval.
+
+### Rollback and cleanup
+
+
+- This draft itself performs no external action and needs no remote rollback.
+- If the future source check, dependency resolution, package build, tracer, or cancellation proof fails, stop and record the observation in `Drift`; do not substitute another beta or broaden into app/backend work.
+- Before leaving the implementation lane, restore test globals/environment, remove fixture listeners/timers, await/interrupt every owned fiber, and confirm no active local request remains. Do not write credentials, raw PII, receipt photos, or raw payloads into evidence.
+- If the slice is abandoned before acceptance, discard/revert only the named SDK files and required root lockfile entry in the writer worktree. Preserve the canonical v3 branch and current Symfony route; do not publish or migrate consumers. No provider/data cleanup is permitted because none may exist.
+- A rollback to the v3 branch is a compatibility rollback, not evidence that the Railway fallback is acceptable. The fallback remains a known ADR defect and must not be used for a preview or production claim.
+- If a later implementation observation disagrees with this intent, link the observation and conflicting artifact, keep the lane in `Drift`, and return to `Specified` for intent change or `Building` for implementation correction under lifecycle authority.
+
+## Dependencies, conflicts, and drift log
+
+### Dependencies and concurrency
+
+- **Required predecessor:** accepted Stage-0 ADR 0001 and the accepted local-preview authority. They provide topology, SDK-seam, explicit-configuration, and operator boundaries; this SDK fixture does not depend on the preview implementation branch or on a provider runtime.
+- **Parallel lanes:** clean-checkout bootstrap, local-preview implementation/documentation, and team-to-department domain evidence may proceed in separate worktrees when their mutable paths remain disjoint. This lane owns SDK paths; it does not own app/server/domain/preview paths.
+- **Successors:** SDK seam freeze, consumer reconciliation, and Receipt Worker work wait for this compatibility evidence plus their own accepted specs and gates. This lane does not wait for a backend implementation and cannot claim one.
+- **Shared resource:** root `bun.lock` is required by this lane; the clean-bootstrap lane does not reserve it, but any later sibling touching it is serialized before mutation. Treat the lockfile as owned by this capsule while its ordinary refresh and frozen verification run. No concurrent writer may edit or overwrite it.
+- **No operator authorization:** no credential, provider, remote, deployment, publication, data, route, or public action is needed or permitted.
+
+### Drift / unresolved source questions
+
+| ID | Observation/question | State and return path |
+|---|---|---|
+| `D-0003-1` | Capability reference evaluated upstream beta.106, while the official npm dist-tag now reports beta.107. | Open until the future writer re-fetches beta.107 metadata/source/signatures at implementation start. A changed dist-tag or manifest returns to `Specified`/`Drift`; beta.106 is not an allowed fallback. |
+| `D-0003-2` | The exact v4 Schema decoder/transformation signatures and exact package-wide compatibility of all current v3 SDK modules must be checked against beta.107 source/types. | Open boundary question until fresh source inspection and full SDK build; a mismatch enters `Drift` and blocks the lane rather than inviting a probe package. |
+| `D-0003-3` | Exact v4 cancellation observation must prove that the signal supplied to the async constructor reaches the underlying fetch and that owner interruption terminates all local work. | Open boundary question until E10. If the fixture remains active after interruption, enter `Drift` and return to `Specified` for a design correction or reject v4 for this SDK lane. |
+| `D-0003-4` | `@effect/platform` has no v4 release and is unused; `@effect/vitest` has a beta.107-compatible release with current Vitest `>=4.1` but is unused. | Remove both unless fresh source proves one is required and records an exact compatible pin. Any contrary package/source fact enters `Drift`; never install v3 to force green. |
+| `D-0003-5` | Removing the Railway fallback and making absent `apiUrl` explicit will expose stale app assumptions. | Deliberate downstream risk. Apps remain outside this spec; consumer lane must adapt explicitly before any seam freeze or preview. |
+| `D-0003-6` | Under Bun `1.3.13`, literal `bun --cwd packages/sdk run build/test` prints usage and exits `0` without running the package scripts. | Resolved command-shape correction: verification uses `bun --cwd=packages/sdk run build` and `bun --cwd=packages/sdk run test`; this changes syntax only, not implementation, status, or intent. |
+
+Current entry: Status is `accepted` after independent review and product-lead acceptance on `2026-08-10`; implementation has not started. An observed Bun `1.3.13` command-shape Drift is resolved by using `bun --cwd=packages/sdk run build` and `bun --cwd=packages/sdk run test`; no implementation, status, or intent change follows.
+Any new disagreement among this spec, the lifecycle, charter, ADR, domain model, SDK source, official beta source, or runtime observation enters `Drift` with owner, evidence, and proposed return. The writer does not resolve authority conflicts by editing the easiest file.
+
+## Lifecycle gates
+
+- **Specified:** gate satisfied; this complete draft exists at the stable live-spec path with resolvable authority, dependency, contract, evidence, falsifier, and capsule sections.
+- **Ready:** gate passed after independent review and explicit product-lead acceptance on `2026-08-10`; status is `accepted`. Implementation has not started.
+- **Building:** only in an isolated worktree under the task capsule, with the accepted paths and boundaries above. The product lead remains read-only to production code.
+- **Experienceable:** after the complete deterministic tracer, full SDK build/export proof, sanitized evidence, and one-to-one PR exist; the feature lead freezes the accepted spec as the one-to-one PR opens. A remote PR is not opened without operator authority.
+- **Conforming:** a blind-first verifier receives the frozen spec, implementation, and evidence before author rationale; the author does not self-verify.
+- **Release-ready / Operating:** not entered. Publication, consumer migration, route cutover, backend replacement, provider effects, and production use require later accepted specs and operator authority.
+
+## Task capsule — future bounded writer
+
+| Field | Capsule content |
+|---|---|
+| Spec ID/path | `0003`; `mono-web/design-specs/0003-effect-v4-receipt-sdk-compatibility.md` |
+| Role/objective | Single writer `EffectSdkImplementer`; migrate the real SDK to exact Effect beta.107 and produce the one local Receipt tracer plus full SDK build/export, strict boundary, typed-error/configuration, fail-closed, and interruption evidence. |
+| Base/worktree | Start from accepted 0003 spec branch tip `7354b3c5027631a005c0e2551460c6ce3d6af689`, whose code baseline is `12c1f3ea6ab1b29d760ed60853c90e46e1aa466d`; use the pre-defined manual worktree `/tmp/mono-web-effect-v4-receipt-sdk-impl-20260810` on branch `mono-web-effect-v4-receipt-sdk-impl-20260810` unchanged; record the checkpoint and worktree in the handoff before mutation. |
+| Allowed mutations | `mono-web/packages/sdk/package.json`; `mono-web/packages/sdk/tsconfig.json` only if the verified v4 compiler boundary requires a minimal compatible setting and it MUST NOT be narrowed; `mono-web/packages/sdk/src/**`, including existing transport/config/domain/schema/error files and new or updated SDK tests under `src/__tests__/**`; required root `mono-web/bun.lock`. `mono-web/packages/sdk/openapi.json` remains forbidden; generated `dist`/cache/log state is disposable. |
+| Root-lock custody | `EffectSdkImplementer` is the sole owner of root `bun.lock` for this capsule. Obtain the scheduler handoff before ordinary `bun install`; no sibling writer may mutate the lockfile concurrently. |
+| Forbidden actions | Every app/server/domain/provider/OpenAPI/route/workflow/root-manifest path; app lockfiles; Cloudflare/Alchemy/Wrangler/provider commands; credentials, production data, remote access, deployment, publication, route cutover, consumer migration, raw-fetch cleanup, public API redesign, shipped probe package, or Promise-only cancellation workaround. |
+| Dependencies/conflicts | Accepted ADR 0001 and local-preview authority; fresh official beta.107 source/signature check; required lockfile custody; SDK evidence precedes seam freeze, consumer lane, and Receipt Worker lane. Current stale app manifests/imports are separate downstream risk. |
+| Context/law/interface refs | Lifecycle §§2, 4–6, 8–12; charter §§1–5 and 9–12; ADR §§2, 4, 7, 9, 12, 14–15; domain model §2.5 (`T-REC-1`, `S-REC-1`, `S-REC-2`); capability reference §§2, 7–11; current SDK sources and Receipt OpenAPI paths. |
+| Exact skills | Effect v4 source/signature verification; bounded SDK/Schema/transport work; structured cancellation/resource ownership; writing and evidence discipline. Do not use a provider/deployment skill. |
+| Sensitive-data policy | Synthetic fixture only; no credentials, PII, receipt photos, production payloads, provider access, or external network. Keep `trace-token` in memory and redact all evidence. |
+| Verification commands/scenarios | Fresh npm metadata/source/signature/provenance check; ordinary `bun install` then `bun install --frozen-lockfile`; full `packages/sdk` build and test; public export/apiUrl guards; client configuration failure; authenticated Hydra list; approve→refunded 204→void; malformed Hydra/member and invalid date; 401/403/404/409/422/429/other/network/config mapping; owned-fiber interruption with aborted signal and zero active work; scope review. |
+| Exit criteria | E0–E11 are recorded; full SDK package build/tests and public export checks pass; required root lockfile is exact; worktree is clean; no unresolved Drift linked to this spec/dependencies/lockfile remains; feature lead accepts the handoff for independent blind-first verification. |
+| Evidence destination | Sanitized **Evidence** section of the future one-to-one PR. Without remote/PR authority, retain only the sanitized evidence in the branch-tip task handoff; add no repository evidence file. |
+| Drift path | Stop on any falsifier or source mismatch; notify product lead; link this spec, lifecycle, charter, ADR, domain law, capability reference, and observation. Return to `Specified` for intent change or `Building` for implementation-only correction. |
+| Cleanup | Restore test globals/environment; remove fixture listeners/timers; await/interrupt owned fibers; confirm zero active work; discard generated dist/cache/log state; leave no credentials or raw payloads. No remote cleanup is permitted. |
+| Operator authorization | None is needed or permitted. Any external effect requires stopping and a separately recorded lifecycle-scoped operator authorization; the writer has no standing authority. |

--- a/design-specs/0005-cloudflare-alchemy-preview.md
+++ b/design-specs/0005-cloudflare-alchemy-preview.md
@@ -1,0 +1,471 @@
+# Live design spec 0005 — Cloudflare Alchemy v2 non-production preview
+
+> **Summary:** One post-checkpoint-1 maintainer/operator journey that deploys the existing synthetic PreviewSpine Worker to one isolated, non-production Cloudflare stage through Alchemy v2, proves the returned preview URL, and destroys the stage before an explicit expiry. The draft separates credential-free local implementation checks from provider-bound plan, deploy, reachability, rollback, and destroy evidence. It is not a production deployment, route cutover, domain decision, domain-conformance proof, or standing authorization.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| Stable ID | `0005` |
+| Status | `accepted` — 2026-08-10 after independent review and product-lead acceptance; local implementation/evidence at source HEAD `8ab3d5cc` is Building-complete and pre-freeze; no feature-lead freeze, one-to-one PR, objective journey under authority, blind-first frozen-spec gate, operator provider authorization, provider run, Cloudflare URL, or deployment claim |
+| Checkpoint | 2 — isolated non-production Cloudflare deployment after accepted checkpoint 1 |
+| Predecessor | [`0001-cloudflare-local-preview-spine.md`](./0001-cloudflare-local-preview-spine.md), accepted checkpoint 1 |
+| Owner | Feature lead/specifier; product lead remains read-only to production code |
+| Intended implementation lane | Alchemy v2 Cloudflare preview spine |
+| Journey count | One maintainer/operator journey; one future implementation PR |
+| Draft date | `2026-08-10` |
+| Base for the future writer | Exact verified integration candidate `8a16ea999d2aa6ddd8ab0982478d701263183795`; verify its `infra/preview.worker.ts` is byte-identical to checkpoint-1 tip `af069395` before mutation; this draft changes no implementation path |
+
+## Authority and source routing
+
+This is a live design spec for one journey. It does not copy authority owned by the accepted architecture decision, program charter, lifecycle, or domain model.
+
+| Concern | Authority | Use in this spec |
+|---|---|---|
+| Accepted topology and preview order | [`ADR 0001`](../../docs/decisions/0001-cloudflare-topology-and-migration-architecture.md), especially §§1, 3, 5, 6, 11, 12, 14–16 | Checkpoint 1 precedes checkpoint 2; Alchemy is the sole Cloudflare declaration/deployment spine; no provider authority is implied; PR stages are non-production and synthetic. |
+| Program order and operator boundary | [`Product lead charter`](../../docs/product-lead-charter.md), especially §§2, 4–7, 9–10, 12 | Checkpoint 2 follows checkpoint 1; product lead is read-only; operator owns credentials, provider effects, cleanup, rollback closure, and retirement. |
+| Lifecycle, gates, capsules, evidence, and Drift | [`Agentic development lifecycle`](../../docs/agentic-development-lifecycle.md), especially §§2, 4–10, 12 | This accepted spec's local implementation/evidence is Building-complete and pre-freeze; Experienceable requires a feature-lead freeze, one-to-one PR, and objective journey under authority, while Conforming requires blind-first review of frozen spec/implementation/objective evidence before rationale and no linked Drift; provider work remains blocked on scoped authority. |
+| Domain meaning | [`Domain model`](../../docs/domain-model.md) | The health response is an operational synthetic fixture. This journey invokes no domain law, SDK contract, backend, persistence, authorization, or production data. |
+| Checkpoint-1 HTTP contract and local boundary | [`0001` accepted local spine](./0001-cloudflare-local-preview-spine.md), especially §§4, 6, 8, 9, 11, 13, 16 | Reuse the exact raw Worker and its credential-free local evidence; do not turn the local Alchemy falsifier into a credential workaround. |
+| Implementation | Future writer's named branch/worktree and one-to-one PR | The implementation cannot silently change this intent or add a resource, route, credential, state store, or data source. |
+| Provider/runtime observation | Operator's sanitized observation record named by the future PR | It proves only the stated stage, action, URL, time window, and fixture response. |
+
+The accepted checkpoint-1 spec records that credential-free `alchemy plan`/`alchemy dev` was falsified: the CLI required Cloudflare credentials before starting a Worker, and synthetic account values were not a workaround. This draft therefore does **not** prescribe an Alchemy local run. The first local checkpoint remains the official Wrangler path in `0001`; this checkpoint is deliberately provider-bound.
+
+## Goal, constraints, and values
+
+### Goal
+
+After checkpoint 1 evidence passes, give one operator and one bounded writer a repeatable way to:
+
+1. install and locally inspect the exact Alchemy v2 dependency graph without provider credentials;
+2. declare exactly one existing synthetic Worker in a future root `alchemy.run.ts`;
+3. obtain an operator-scoped, non-production authorization before any provider call;
+4. run a read-only Alchemy plan and an explicitly approved Alchemy deploy against one explicit PR stage;
+5. reach the returned non-production `workers.dev` preview and observe the inherited health/404/405 contract; and
+6. roll back or destroy the stage before its recorded expiry, revoke the temporary authority, and leave no remote preview resource.
+
+### Constraints
+
+- **Ordered checkpoint:** checkpoint 1's accepted local evidence is a hard predecessor. No provider command, profile use, remote state bootstrap, deploy, public preview, or cloud observation may begin until the predecessor evidence and this spec have both passed their applicable gates.
+- **Verified implementation base:** the future writer starts at exact candidate `8a16ea999d2aa6ddd8ab0982478d701263183795` and proves `infra/preview.worker.ts` is byte-identical to checkpoint-1 tip `af069395`; the writer must not recreate or alter that file.
+- **Single deployment spine:** Alchemy v2 is the only Cloudflare resource declaration and cloud deployment tool in this slice. Do not add Wrangler deploy, Wrangler versions upload, dashboard edits, Terraform, another IaC tool, or a second resource declaration.
+- **One resource:** the future declaration contains one `Cloudflare.Worker` logical resource, `PreviewSpine`, whose `main` is the existing `./infra/preview.worker.ts` from checkpoint 1. It has no bindings, assets, storage, queues, Durable Objects, Hyperdrive, D1, secrets, service bindings, `Cloudflare.Website.Vite`, gateway, or origin.
+- **One explicit stage:** every provider command supplies an operator-recorded stage such as `pr-<number>` and an operator-recorded profile. Never use Alchemy's implicit `dev_$USER`, `dev_unknown`, `staging`, or `prod` stage for this journey. The stage name must satisfy Alchemy's documented grammar and be unique to this run.
+- **Local state, no bootstrap:** the Stack uses `Alchemy.localState()` and stores disposable state under `.alchemy/`. It does not use `Cloudflare.state()`, remote state, or the state-store bootstrap. If a writer needs remote state, account-wide state-store resources, or a shared state owner, stop and enter `Drift`; that is a separately accepted decision, not an implementation detail.
+- **Reachability boundary:** `workersDev: { enabled: true, previewsEnabled: false }` is the only permitted cloud reachability surface for this preview: it exposes the stable synthetic `workers.dev` URL and disables version preview URLs. The Worker declares no `routes` and no `domain`; there is no zone route, custom domain, DNS action, API gateway route, public production endpoint, route manifest, or route cutover. A `workers.dev` URL is a non-production preview surface and may be publicly reachable; it must serve only the synthetic fixture. `PreviewSpine` is the ADR §8 raw preview candidate, not a private context Worker.
+- **No production:** the stack, stage, profile, account, zone, domain, data, credentials, bindings, and observations are non-production. No production identifier may appear in code, output, URL, request, log, or fixture. The writer must not infer that an account, workers.dev subdomain, quota, plan, Access policy, zone, or token scope exists; the operator records what is actually available.
+- **Credential boundary:** no credential, token, API key, `.env`, `.env.*`, `.dev.vars`, `.dev.vars.*`, profile file, PII, production data, or account identifier enters the repository or the writer's evidence. The operator keeps credentials in an operator-controlled profile or environment and invokes provider commands. Dummy or synthetic provider values are forbidden.
+- **Telemetry boundary:** every future provider-bound Alchemy plan, deploy, and destroy command is prefixed with `ALCHEMY_TELEMETRY_DISABLED=1`. The operator records that the observed `https://otel.alchemy.run/v1/{traces,metrics,logs}` boundary was disabled and that no unlisted telemetry path occurred; this is an egress boundary, not provider authorization.
+- **No standing authority:** this spec, the accepted ADR, a declaration, a package install, a plan output, or a deployment log grants no Cloudflare/Alchemy authority. Authority is a separate, time-bounded operator record for the named stage and actions.
+- **No domain claim:** the response is synthetic operational output. It does not claim API parity, SDK compatibility, frontend buildability, domain conformance, authorization, data isolation beyond the observed boundary, availability, performance, or production readiness.
+- **No current app repair:** `apps/homepage`, `apps/dashboard`, `apps/server`, `packages/sdk`, the SDK's workspace-wide `effect@4.0.0-beta.107` dependency, React Router compatibility, MySQL, and all application data remain outside this slice. The SDK has no `@effect/platform` dependency; none of these current app/SDK facts is a root Alchemy version authority.
+- **No provider action in this drafting task:** this change creates only this draft spec. It does not install dependencies, invoke Alchemy, invoke Wrangler, contact Cloudflare, read a profile, change a package, alter a lockfile, or create a cloud resource.
+
+### Values
+
+- **Local-first, provider-honest:** perform every credential-free check before the operator boundary, and do not pretend the provider-bound part is local.
+- **Least authority:** authorize one stack, one stage, one Worker, one preview surface, one bounded time window, and only the commands needed for this journey.
+- **One journey, one spine:** one future `alchemy.run.ts`, one declarative resource graph, one objective health journey, and one cleanup path.
+- **Evidence over implication:** plan output proves a plan; deploy output proves provisioning; an HTTP observation proves only the observed URL and fixture; none proves domain behavior.
+- **Disposable and reversible:** the stage, local state, URL, and operator capability are temporary; the Symfony line and production routes remain untouched.
+- **Honest uncertainty:** unknown account capabilities are inputs for the operator, not assumptions for the writer.
+
+## Current behavior and intended behavior
+
+### Current behavior (baseline)
+
+At the accepted repository checkpoint used for this draft:
+
+- The root `package.json` declares Bun `1.3.10` as the package manager and has no `alchemy.run.ts`, Alchemy dependency, or cloud-preview script. At exact base `8a16ea999d2aa6ddd8ab0982478d701263183795`, the SDK manifest pins `effect@4.0.0-beta.107` and declares no `@effect/platform` dependency; that SDK pin is not the root Alchemy lane's separate version authority, while the future root Alchemy pins may resolve alongside the same workspace-wide Effect beta.
+- Accepted checkpoint 1 supplies the raw Worker at `infra/preview.worker.ts` in its implementation tip (`af069395`), and the verified integration candidate for this lane is exact commit `8a16ea999d2aa6ddd8ab0982478d701263183795` with that file byte-identical. The exact `wrangler@4.120.0`/Node `>=22`/local-workerd contract remains in `0001`; this draft must not alter or recreate that local contract.
+- No Alchemy state, Cloudflare profile, Cloudflare account, zone, domain, route, remote state store, cloud Worker, or production preview is claimed to exist.
+- No account capability is known from the repository: workers.dev availability, account limits, token permissions, Cloudflare Access policy, naming availability, billing, and state-store permissions are all operator-owned inputs.
+
+### Intended behavior after an accepted implementation
+
+A bounded writer may add the Alchemy declaration and exact root dependency/ignore entries named in [Task capsule](#task-capsule). The writer must preserve checkpoint 1's local Worker behavior and must produce no provider evidence without an operator's scoped action record.
+
+The future implementation must realize this graph:
+
+```mermaid
+flowchart LR
+    L[0001 accepted local evidence] --> S[0005 accepted + exact local checks]
+    S --> A[Operator scope record]
+    A --> P[Alchemy plan<br/>read-only provider action]
+    P --> D[Operator-approved Alchemy deploy<br/>apply path]
+    D --> U[One workers.dev URL<br/>synthetic health]
+    U --> R[Reachability + failure observations]
+    R --> X[Operator rollback or destroy<br/>before expiry]
+    X --> C[No live Worker + local state discarded<br/>authority revoked]
+```
+
+**Reading the diagram:** Local implementation checks precede the provider boundary. Plan, deploy, reachability, rollback, and destroy are provider-bound evidence owned or performed by the operator. A deployment output cannot skip the URL journey or cleanup.
+
+## Dependency and version authority
+
+The future writer must use exact direct versions, not `next`, `latest`, `^`, `~`, or an unresolved range. The authority chain is recorded here so the root manifest and `bun.lock` cannot silently drift:
+
+| Direct package | Exact pin for this draft | Official authority and interpretation |
+|---|---:|---|
+| `alchemy` | `2.0.0-beta.70` | The official npm registry currently reports `latest` and `next` as `2.0.0-beta.70` at the draft date: [`alchemy` dist-tags](https://registry.npmjs.org/alchemy) and [`alchemy@2.0.0-beta.70` metadata](https://registry.npmjs.org/alchemy/2.0.0-beta.70). The manifest must pin the exact release rather than the moving `next` tag. |
+| `effect` | `4.0.0-beta.107` | Alchemy's official install/peer authority requires `effect@>=4.0.0-beta.102 || >=4.0.0`, so the already accepted workspace-wide SDK pin `4.0.0-beta.107` satisfies the floor; see [`Getting started — Install`](https://alchemy.run/getting-started/#install) and the [`alchemy@2.0.0-beta.70` metadata](https://registry.npmjs.org/alchemy/2.0.0-beta.70). This is the one Effect version allowed in the root lock. |
+| `@effect/platform-bun` | `4.0.0-beta.107` | Alchemy's official install/peer authority requires the Effect platform family at `>=4.0.0-beta.102`; official npm metadata currently publishes this package at `4.0.0-beta.107`, so pin the current exact publication: [`Getting started — Install`](https://alchemy.run/getting-started/#install) and [`@effect/platform-bun` metadata](https://registry.npmjs.org/@effect%2fplatform-bun). It shares the root's single `effect@4.0.0-beta.107` peer; do not add another Effect beta. |
+| `@effect/platform-node` | `4.0.0-beta.107` | Alchemy's official install/peer authority requires the Effect platform family at `>=4.0.0-beta.102`; official npm metadata currently publishes this package at `4.0.0-beta.107`, so pin the current exact publication: [`Getting started — Install`](https://alchemy.run/getting-started/#install) and [`@effect/platform-node` metadata](https://registry.npmjs.org/@effect%2fplatform-node). It shares the root's single `effect@4.0.0-beta.107` peer; do not add another Effect beta. |
+| `wrangler` | `4.120.0` | Inherited unchanged from accepted checkpoint 1; see [`0001` exact dependency boundary](./0001-cloudflare-local-preview-spine.md#dependency-and-resource-graph). Do not add a second Wrangler deployment path. |
+
+The official Alchemy page intentionally publishes the moving `alchemy@next` tag and compatible Effect/platform requirements. The exact lock choice above is the reproducible checkpoint-2 baseline: root `effect@4.0.0-beta.107` is the already accepted SDK/workspace pin and satisfies Alchemy's `>=4.0.0-beta.102` peer floor; `@effect/platform-bun` and `@effect/platform-node` are pinned to their current exact beta.107 publications. The root lock must contain one Effect-family version (`4.0.0-beta.107`) and no duplicate `effect@4.0.0-beta.102` or mixed platform beta. Before implementation, the writer must re-read the official install page, peer metadata, and exact registry metadata. If either authority changes, or the exact pins no longer install together, stop and record `Drift`; do not silently substitute a newer package or relax the lock.
+
+The accepted workspace SDK's `effect@4.0.0-beta.107` pin is not a version authority for the Alchemy lane by itself; the official peer floor is the authority, and the root uses that same beta.107 pin so Alchemy/platform packages can resolve alongside the SDK without a duplicate Effect beta. The future writer changes only the root manifest/lock entries named by the capsule; no app or SDK manifest may be migrated in this slice.
+
+## Dependency and resource graph
+
+| Graph item | Required shape | Evidence/boundary |
+|---|---|---|
+| Entrypoint | Root `alchemy.run.ts` | Alchemy CLI default entrypoint; no alternate stack file, workflow, or Wrangler config. |
+| Stack | `Alchemy.Stack("MonoWebPreview", ...)` | Stable logical stack identity; never use a production stack name. |
+| Provider layer | `Cloudflare.providers()` only | Alchemy sole Cloudflare provider declaration; no AWS, GitHub, Neon, or other provider. |
+| State layer | `Alchemy.localState()` | `.alchemy/` local state, scoped by stack and explicit stage; no `Cloudflare.state()` bootstrap or remote state. |
+| Worker | `Cloudflare.Worker("PreviewSpine", { main: "./infra/preview.worker.ts", workersDev: { enabled: true, previewsEnabled: false } })` | Exactly one raw ADR §8 preview resource; no private context-Worker role, bindings, assets, storage, route, domain, or production reference. |
+| Stage | Explicit `pr-<number>` or operator-approved equivalent matching Alchemy's documented grammar | Never default, `staging`, or `prod`; one writer/operator per stage. |
+| Profile | Explicit operator-controlled non-production profile | Never rely on default profile discovery; no profile file enters the worktree. |
+| Reachability | `worker.url` output, expected to be a workers.dev preview only if the operator's account supports it | Account capability is unknown until observed; no custom domain/zone route fallback is permitted. |
+| Local state | `.alchemy/state/<stack>/<stage>/...` (ignored and disposable) | Keep until remote destroy is observed; then discard locally and do not commit. |
+
+### Future `alchemy.run.ts` declaration shape
+
+The following is the intended declaration shape, not an implementation in this draft. The future writer must validate it against the exact pinned packages and may not add omitted properties without a product-lead-reviewed revision:
+
+```typescript
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+
+export default Alchemy.Stack(
+  "MonoWebPreview",
+  {
+    providers: Cloudflare.providers(),
+    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () {
+    const worker = yield* Cloudflare.Worker("PreviewSpine", {
+      main: "./infra/preview.worker.ts",
+      workersDev: { enabled: true, previewsEnabled: false },
+    });
+
+    return { url: worker.url.as<string>() };
+  }),
+);
+```
+
+This shape follows the official [Alchemy Stack composition-root guidance](https://alchemy.run/infrastructure-as-code/stack/) and [Cloudflare Worker resource guidance](https://alchemy.run/providers/cloudflare/workers/worker/). `workersDev: { enabled: true, previewsEnabled: false }` explicitly enables the stable synthetic `workers.dev` URL while disabling version preview URLs. `PreviewSpine` is the ADR §8 raw preview candidate, not a private context Worker. `routes`, `domain`, `env`, `bindings`, `assets`, `version.parent`, and all storage/resource declarations are intentionally absent.
+
+## Synthetic Worker behavior
+
+The cloud preview reuses the accepted checkpoint-1 `infra/preview.worker.ts`; it must not call the SDK, Symfony, MySQL, an external API, a queue, a secret, or a domain service. The body is an operational fixture, not domain data:
+
+| Request | Required provider-bound observation |
+|---|---|
+| `GET <worker.url>/health` | `200`; JSON content type equivalent to `application/json; charset=UTF-8`; `Cache-Control: no-store`; body exactly `{ "service": "mono-web", "purpose": "cloudflare-local-preview-spine", "status": "ok" }`. |
+| `GET <worker.url>/unknown-route` | `404`; it must not be accepted as a health or success path. |
+| `POST <worker.url>/health` (and any non-GET method) | `405` with `Allow: GET`; it must not execute the health path. |
+| Any other route/method | No success claim; record the observed status and enter `Drift` if it exposes an unexpected success or data path. |
+
+The inherited `purpose` value names the raw synthetic fixture from checkpoint 1. It is deliberately not a stage, account, domain, user, department, receipt, application, production, or release identifier. A future writer who wants a different body must revise this spec through `Drift`; do not mutate the local contract as an incidental cloud change.
+
+## One objective journey
+
+This is one end-to-end maintainer/operator journey. It has a credential-free local lane and a provider-bound operator lane; those lanes are evidence boundaries within the same journey, not separate feature journeys.
+
+### Lane A — credential-free local implementation verification
+
+1. Start from the accepted checkpoint-1 clean checkout and record the exact base commit, branch, worktree, and `0001` evidence reference. Do not start from a dirty or unknown base.
+2. Run the checkpoint-1 filename-only credential preflight. A root `.env`, `.env.*`, `.dev.vars`, or `.dev.vars.*` match is `Drift`; never open, inspect, copy, or load the matching file. No provider profile or credential may be present in the writer's worktree.
+3. Re-read the official install/version sources, add the exact pins from [Dependency and version authority](#dependency-and-version-authority) only to the root manifest, and regenerate `bun.lock` before the frozen install. This is credential-free dependency work; no Cloudflare request is allowed.
+4. Run the locked dependency install with `bun install --frozen-lockfile`. Installation traffic to npm is installation evidence, not provider or production evidence.
+5. Verify the root manifest and lockfile contain exact `alchemy@2.0.0-beta.70`, `effect@4.0.0-beta.107`, `@effect/platform-bun@4.0.0-beta.107`, and `@effect/platform-node@4.0.0-beta.107` pins, with only that one Effect-family version, preserve `wrangler@4.120.0`, preserve the root package manager, and leave every app/package manifest unchanged.
+6. Review or type-check the future `alchemy.run.ts` without importing a profile or invoking a provider command. Confirm the Stack has exactly `Cloudflare.providers()` + `Alchemy.localState()` and exactly one `PreviewSpine` Worker pointing at `./infra/preview.worker.ts`; confirm no route, domain, binding, resource, production string, `Cloudflare.state()`, `Alchemy.remote()`, `--adopt`, `unsafe nuke`, dashboard, or Wrangler deploy path is introduced.
+7. Verify `.alchemy/` is ignored before any local state is generated. Reuse checkpoint 1's already accepted local Worker evidence; if the writer re-runs it, inherit `0001`'s exact Node-hosted Wrangler command, all four egress controls, pinned compatibility date, HTTP/stop contract, and closed-port checks—not `0001`'s dependency boundary. Never use `alchemy dev` as a substitute or a provider credential workaround.
+8. Stop here and hand the local transcript to the feature lead. The writer does not run any provider/remote command. The local lane cannot claim a cloud URL, provider authorization, deployment, or destroy.
+
+### Boundary — operator authorization before provider work
+
+9. Before any provider-bound command, the operator creates and signs the scope record in [Operator decision record](#operator-decision-record). The record must name the exact stack, stage, account/profile/environment, Worker/resource set, commands/actions, actor, expiry, revocation path, and `ALCHEMY_TELEMETRY_DISABLED=1` egress boundary. The record must explicitly exclude production, custom domains, zone routes, route cutover, application data, secrets in the Worker, and any unlisted resource.
+10. The operator configures the named profile or short-lived capability outside the repository and inspects the credential-free `.alchemy/` local state path before provider work. The writer receives no raw token, API key, profile file, `.env`, or account secret. The operator uses explicit `--stage` and `--profile` values and does not rely on Alchemy defaults or a repository `--env-file`.
+11. If the operator cannot establish the exact non-production account, profile, workers.dev policy, permission scope, telemetry-disabled boundary, or credential-free local-state inspection, stop with `Drift`. Do not insert a dummy account ID, synthetic token, guessed zone, or alternate provider command.
+
+### Lane B — provider-bound plan, deploy, reachability, and cleanup
+
+12. The operator runs the official Alchemy **plan** command as `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy plan alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE"`. `plan` is read-only with respect to desired resource changes, but it is still a provider-bound authenticated action and needs the scope record. Capture sanitized output and the disabled-telemetry observation.
+13. The operator verifies that the plan contains exactly one `Cloudflare.Worker` create/update for `PreviewSpine` in the named stage, with no `Cloudflare.state()` bootstrap, state-store Worker, Durable Object, Secrets Store, route, domain, binding, storage, gateway, or production resource. Any additional resource or unexpected stage is a falsifier.
+14. Only after the operator approves that exact plan does the operator run Alchemy **deploy** as `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy deploy alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE" --yes`, which is the official plan/approval/apply path. A standalone `alchemy apply` command is not assumed; the official CLI documents `deploy` as the command that computes a plan, asks for approval, and applies it. `--yes` is allowed only when the operator's record explicitly authorizes that apply action. Capture the redacted output and returned `worker.url`.
+15. The operator probes the returned URL over HTTPS. The probe must record the URL, timestamp, stage, response status, relevant headers, and exact body for `GET /health`, `GET /unknown-route`, and `POST /health`. It must not send credentials or production data. A `workers.dev` URL may be public; the fixture contains no secrets or domain data.
+16. If any response, URL, resource count, route surface, stage, state path, or output differs from this spec, stop requests and enter `Drift`. Do not repair by adding a route, changing the Worker body, using Wrangler, opening the dashboard, adding credentials, or redeploying an unreviewed declaration.
+17. If the operator observes a failing deployment or incorrect response, the operator may invoke the pre-authorized rollback path in [Rollback](#rollback). Rollback evidence must identify the action actually taken; this spec never claims that rollback happened merely because a plan or deploy log exists.
+18. Before `expiresAt`, the operator uses the exact checkout/commit, root `alchemy.run.ts`, stack `MonoWebPreview`, stage, profile, and `.alchemy/` local state that recorded deploy. The operator first runs `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy destroy alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE" --dry-run` from that same checkout/state and requires explicit `PreviewSpine` deletion; an empty or no-op destroy plan is `Drift`. Only then may the operator run the pre-authorized `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy destroy alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE" --yes` from the same boundary. Capture sanitized plan and deletion output for the one Worker, verify the old URL is unreachable (connection failure or a non-success response, never the health `200`), and verify no live resource remains in the named Alchemy state.
+19. After remote absence is observed, the operator discards `.alchemy/` local state, records residual risk, revokes or expires the temporary provider capability, and reports the final evidence. The writer never deletes a profile, rotates a token, or claims revocation without the operator's record.
+
+## Operator decision record
+
+The following is a required input, not a default. The product lead charter and lifecycle require the operator to record scope, actor, environment, action, expiry, and revocation for external effects. A missing field blocks the provider lane.
+
+| Field | Required decision/evidence | Not allowed |
+|---|---|---|
+| Scope | Exact stack `MonoWebPreview`; exact stage `pr-<number>`; exact one Worker `PreviewSpine`; exact output URL policy; exact local-state owner; exact checkout/commit and `.alchemy/` state path used for plan/deploy/destroy; explicit exclusion of production, routes, domains, data, and extra resources | Broad account access, wildcard stages, inferred branch/hostname scope, or account-wide cleanup |
+| Actor | Named operator or named operator-controlled automation; identify who approves plan, apply, reachability observation, rollback, destroy, and revocation | Anonymous agent authority, writer self-approval, or authority inferred from product-lead acceptance |
+| Environment | Named non-production Cloudflare account/profile/environment and the stage; account ID may remain operator-held and redacted in repository evidence | Guessed account, production profile, default profile, `prod`/`staging` stage, or unrecorded account capability |
+| Action | `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy plan` (read-only provider action), approved `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy deploy` apply, HTTPS synthetic probes, stage-scoped `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy destroy`, and any rollback command actually authorized | `alchemy login` by the writer, Wrangler deploy, dashboard edits, `--adopt`, `unsafe nuke`, route/DNS actions, or unlisted resources |
+| Expiry | Absolute `expiresAt` and a destroy-by time at or before it; no indefinite preview | Missing expiry, “until someone remembers,” or an automatic assumption about budget/cost |
+| Revocation | Who revokes the profile/token/capability, when, and how the revocation result is recorded after destroy | Credential copy into the repo, standing profile authority, or a claim that cleanup revoked credentials without operator evidence |
+| Data | Synthetic fixture only; no application payload, PII, production data, secret, database, or external binding | Seeded production data, dummy provider credentials, or credentials treated as fixture data |
+
+The operator must decide whether the named account can provide the workers.dev preview surface and the requested least-privilege permission set. This draft does not assert that it can. If the account cannot satisfy the decision, the correct result is `Drift` or deferral, not a route/domain workaround.
+
+## Authenticated plan/apply boundary
+
+Alchemy's official docs distinguish stage from profile: a stage isolates **what** is deployed, while a profile controls **how** Alchemy authenticates. Both values are explicit inputs here. The plan and deploy commands are provider calls even when the Worker graph is synthetic. Every provider-bound Alchemy plan, deploy, and destroy command below uses `ALCHEMY_TELEMETRY_DISABLED=1`; the operator records the disabled `https://otel.alchemy.run/v1/{traces,metrics,logs}` boundary and enters `Drift` if an unlisted telemetry path is observed.
+
+| Phase | Credential visibility | Allowed actor | Claim it can support |
+|---|---|---|---|
+| Local manifest/lock/declaration checks | None; no profile, token, `.env`, or provider request | Future writer | Exact local dependency and declaration shape only |
+| `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy plan` | Operator-controlled profile/capability; no raw secret in evidence | Operator | Redacted provider plan for the named stage; no resource mutation claim |
+| `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy deploy` | Same bounded capability and explicit operator approval | Operator | Provider provisioning of the planned one-Worker graph for the named stage; not journey/domain proof |
+| HTTPS probes | No deployment credential in request; URL is a provider output | Operator or named probe under operator scope | Observed synthetic HTTP behavior at one URL/time; not production reachability |
+| `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy destroy --dry-run` / `--yes` / rollback | Operator-controlled capability with explicit action in the record | Operator | Recorded stage-scoped deletion or rollback action and its output; not authority to destroy anything else |
+| Profile/token revocation | Operator-controlled credential store | Operator | Revocation/expiry observation only when recorded by the operator |
+
+Use the official CLI's explicit form in the future capsule (the exact profile/stage values are operator inputs, never committed values):
+
+```sh
+# Provider-bound; operator only; no command is run by this drafting task.
+ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy plan alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE"
+ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy deploy alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE" --yes
+ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy destroy alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE" --dry-run
+ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy destroy alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE" --yes
+```
+
+The `--yes` flags are not authorization. They only suppress an Alchemy prompt after the operator has already approved the exact action. The official [plan](https://alchemy.run/cli/plan/) command makes no changes; official [deploy](https://alchemy.run/cli/deploy/) computes a plan and applies after approval; official [destroy](https://alchemy.run/cli/destroy/) supports a `--dry-run` deletion plan before the explicitly approved `--yes` deletion of all resources in that stack/stage. Never use `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy destroy --stage prod`, account-wide `unsafe nuke`, or a profile/default not named in the record.
+
+## Stage, state, and ownership
+
+### Stage isolation
+
+- Stack name is stable: `MonoWebPreview`.
+- Every run uses an explicit, unique non-production stage such as `pr-<number>`, matching Alchemy's documented `[a-z0-9][-_a-z0-9]*` grammar.
+- State and physical names are stage-scoped by Alchemy. A destroy action must carry the same stack, stage, profile, exact checkout/commit, and `.alchemy/` state that plan/deploy used.
+- No command may infer a stage from the branch, user, hostname, missing variable, or account default. No run may target `staging` or `prod`.
+- One writer and one operator own one stage at a time. A second run cannot reuse the stage while the first run has open rollback or cleanup.
+
+These properties follow the official [Alchemy stages](https://alchemy.run/environments/stages/) and [Stack](https://alchemy.run/infrastructure-as-code/stack/) documentation. They do not prove that an operator's account has any particular quota, workers.dev subdomain, or permission; the operator must observe those facts.
+
+### State ownership
+
+- `Alchemy.localState()` is explicit in the declaration. The local state path is `.alchemy/`, with stack/stage namespacing documented by Alchemy. The future writer adds `.alchemy/` to the root ignore rules and proves it is ignored. The operator preserves this exact state path from the deploying checkout through destroy and does not substitute a fresh state directory.
+- The operator owns the live state record and the capability that can mutate it. The writer may inspect only redacted state/plan output required by the capsule; no profile or secret is copied into the worktree.
+- Keep local state until the operator has observed successful stage-scoped destroy. Discard it only after remote absence is recorded. Never commit it or add an evidence file containing state payloads.
+- `Cloudflare.state()` is deliberately absent. The official remote state store can bootstrap an account-scoped Worker, Durable Object, Secrets Store, token, and encryption key on first use. That is an additional resource graph and an account-level ownership decision, so it is outside this one-Worker journey. If remote state becomes necessary, stop with `Drift` and create a separately reviewed decision/spec rather than silently enabling it.
+- The local state directory is disposable coordination state, not a production source of record, domain state, data store, or authorization record. The operator's authorization/observation record remains the authority for external actions.
+
+### Reachability and no-route limits
+
+- `workersDev: { enabled: true, previewsEnabled: false }` is the only permitted URL surface. Alchemy's Worker output must resolve a non-production `workers.dev` URL if the operator's account supports it; the URL is captured as evidence, not hard-coded. Version preview URLs are deliberately disabled.
+- `routes`, `domain`, DNS, zone IDs, custom domains, aliases, redirects, service bindings, gateway manifests, and public API routes are forbidden. A `workers.dev` preview is not a production route and must never receive production traffic or become a route-cutover target.
+- Cloudflare documents workers.dev and preview URLs as potentially public. Therefore the Worker returns only the fixed synthetic fixture and no credentials, PII, application payload, or production identifier. Access policy configuration is not added here; the operator records the observed account policy/capability and stops if the requested exposure is not acceptable.
+- A missing workers.dev subdomain, a plan that proposes a custom route/domain, or any unexpected URL is `Drift`. Do not claim that a route can be created, that a subdomain is enabled, or that the account permits the requested action without an operator observation.
+- The cloud probe is HTTPS reachability of one exact output URL. It is not proof of global availability, DNS ownership, production routing, public API behavior, or an authenticated application journey.
+
+## Rollback, expiry, and cleanup
+
+### Rollback
+
+Rollback is an operator action with evidence, not a promise in this document:
+Rollback and destroy must use the exact clean checkout/commit, `alchemy.run.ts`, stack, stage, profile, and `.alchemy/` state path that produced the provider observation. A command from another checkout or a freshly initialized state path is not evidence for this deployment and enters `Drift`. Every provider-bound rollback/destroy plan or apply command is prefixed with `ALCHEMY_TELEMETRY_DISABLED=1`; the operator records the disabled telemetry observation.
+1. If plan output is wrong, reject it; no resource has been authorized to apply.
+2. If deploy fails before a healthy URL, stop and preserve the output. From that exact checkout/state, the operator may run `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy destroy alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE" --dry-run`, require the partially created `PreviewSpine` deletion, and—only with the authorization record—run `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy destroy alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE" --yes`; do not broaden the graph.
+3. If the health/404/405 observation fails after deploy, stop probes. The operator may redeploy the last-known-good accepted declaration to the same stage **only if that action is explicitly in the scope record**, or run `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy destroy alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE" --dry-run` from the exact checkout/state, require explicit deletion, and then run the same command with `--yes`. Record the chosen action and resulting observation; the draft claims neither rollback nor destroy until its output is observed.
+4. This preview owns no production route and performs no cutover, so there is no route rollback to claim. The existing Symfony line remains untouched and is not switched by this spec.
+5. A failed or partial rollback is `Drift`; the operator may perform an already authorized emergency destroy, but the product lead owns the later lifecycle disposition.
+
+Cloudflare version/deployment behavior is useful context, but this slice does not add `version`, gradual traffic, parent Workers, or a production deployment. A version/deployment log alone cannot prove this journey.
+
+### Expiry and destroy
+
+- The operator records an absolute expiry before plan/apply. The preview must be destroyed at or before that deadline; “temporary” without a timestamp is invalid.
+- The destroy path is the official, stage-scoped `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy destroy alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE" --dry-run` followed, only after explicit `PreviewSpine` deletion is observed and authorized, by `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy destroy alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE" --yes` from the same exact checkout/commit, `alchemy.run.ts`, `.alchemy/` state, stage, and profile. It must be authorized separately or included explicitly in the original action scope.
+- Destroy evidence must show the named `PreviewSpine` Worker deletion, no successful health `200` at the old URL after the provider has settled, and no remaining live resource in the named Alchemy state. A deployment log, local file deletion, or URL disappearance alone is insufficient.
+- If expiry is reached before destroy, stop all probes and enter `Drift`; the operator performs the authorized cleanup and records the lateness. Do not extend the expiry by conversation or silently renew authority.
+
+### Cleanup
+
+1. Stop probes and any local process.
+2. From the exact deploying checkout/state, the operator runs `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy destroy alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE" --dry-run`, verifies explicit `PreviewSpine` deletion, then completes the authorized same-boundary `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy destroy alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE" --yes` and records the output.
+3. Operator verifies no live Worker remains for `MonoWebPreview`/the explicit stage and that the old health path no longer returns the expected `200` fixture.
+4. Only then discard `.alchemy/` local state and generated logs; do not commit them.
+5. Operator revokes or lets the named capability expire and records the result. The writer never reads, copies, deletes, or edits operator credentials.
+6. Report any residual remote state, URL, profile, secret, or unknown account effect as `Drift`; do not hide it with an account-wide cleanup command.
+
+## Lifecycle gates and Drift
+
+### Gate mapping
+
+| Lifecycle state | This spec's condition |
+|---|---|
+| `Need` | ADR/charter identify checkpoint 2 as the next proving slice. |
+| `Specified` | This complete accepted spec names one journey, exact declaration/resource graph, dependency authority, local/provider evidence boundary, rollback, expiry, cleanup, falsifiers, and capsule. Independent review and product-lead acceptance were recorded on 2026-08-10; no provider authority is implied. |
+| `Ready` | Independent review and explicit product-lead acceptance; checkpoint-1 predecessor evidence, base, conflicts, and operator inputs are known. No provider authority is implied. |
+| `Building` | Source HEAD `8ab3d5cc` has implementation and local evidence complete, but this checkpoint remains pre-freeze; no one-to-one PR, objective journey under authority, or provider authorization/run is recorded. |
+| `Experienceable` | Feature-lead freeze, one-to-one implementation PR, and one objective journey under applicable authority with sanitized complete evidence must all exist before this gate; current local evidence does not enter it. |
+| `Conforming` | A blind-first verifier must receive the frozen spec, implementation, and objective evidence before rationale; no linked Drift may remain before this gate. Current local evidence is not `Conforming`; provider work remains unperformed and blocked on scoped operator authorization. |
+| `Release-ready` / `Operating` | Not entered by this preview. Production deployment, public route, cutover, or route rollback require later lifecycle authority. |
+| `Drift` | Any falsifier, authority conflict, version/source change, unexpected resource/effect, runtime disagreement, missing expiry, or incomplete destroy blocks this lane. Product lead routes back to `Specified` for intent change or `Building` for implementation correction. |
+
+### Drift log for this draft
+
+- **Resolved predecessor Drift:** checkpoint 1 records the 2026-08-10 credential-free Alchemy local-preview failure and deliberately routes Alchemy to this operator-authorized cloud slice. Do not reproduce the failed credential-free Alchemy command or add synthetic provider values.
+- **Closed local implementation Drift (Building-complete/pre-freeze):** source HEAD `8ab3d5cc` is the completed local declaration artifact; independent review and local verification PASS were recorded on 2026-08-10. No feature-lead freeze, one-to-one PR, objective journey under authority, blind-first frozen-spec gate, provider authorization, or provider action is recorded.
+- **Unknown account inputs:** workers.dev availability, account/token permissions, Access policy, quota, naming, billing, and state ownership are intentionally unknown. They are not defects until an operator attempts the scoped action; an observation that contradicts this spec becomes `Drift`.
+- **No provider evidence:** local implementation evidence is recorded below; no Cloudflare URL, provider plan, deployment, reachability, rollback, or destroy is claimed. Provider credentials, account/profile use, telemetry, and provider effects remain blocked on scoped operator authorization.
+
+On Drift, preserve the exact conflicting artifact/observation, actor, stage, timestamp, and proposed disposition; notify the product lead and operator; do not resolve the conflict by editing the easiest file or broadening authority.
+
+## Evidence plan and boundaries
+
+### Credential-free local evidence (writer-owned)
+
+The future PR/handoff must contain sanitized evidence for:
+
+- checkpoint-1 acceptance and exact base commit/worktree;
+- root credential-file filename preflight with no matching root `.env`, `.env.*`, `.dev.vars`, or `.dev.vars.*` file and no file contents loaded or inspected;
+- Bun/package-manager preflight and frozen install result, with npm installation traffic distinguished from provider/production traffic;
+- exact direct dependency pins in the root manifest and `bun.lock`, including the official source/version review date;
+- a local declaration/type/module check that does not resolve a provider profile or make a provider call;
+- one `Alchemy.Stack` with `Cloudflare.providers()`, `Alchemy.localState()`, and exactly one `PreviewSpine` Worker; no route/domain/binding/storage/remote state/bootstrap;
+- `.alchemy/` ignore proof and path-scope proof;
+- unchanged checkpoint-1 local Worker evidence or a fresh credential-free Wrangler run under `0001`'s exact command.
+
+This lane proves only local files, dependency resolution, declaration shape, and local synthetic behavior. It cannot prove a cloud plan, provider permission, deployment, workers.dev URL, remote state, account isolation, reachability, rollback, or destroy.
+
+### Recorded local implementation evidence — Building-complete/pre-freeze (2026-08-10)
+
+- Accepted spec blob is exact: `design-specs/0005-cloudflare-alchemy-preview.md` blob `fbb402c4487a5999f13e258ff7126fe41894e83b` at the accepted spec commit and source HEAD. Worker blob is exact: `infra/preview.worker.ts` blob `506df65772912f33973a008c66ac10901e44dd77` at source HEAD, integration base `8a16ea999d2aa6ddd8ab0982478d701263183795`, and checkpoint-1 tip `af069395`.
+- Implementation started and completed locally at that source HEAD; this is Building-complete/pre-freeze, not `Experienceable` or `Conforming`. [AlchemyPreviewCodeReview](agent://AlchemyPreviewCodeReview) is `PASS`; [AlchemyLocalVerifier](agent://AlchemyLocalVerifier) is `PASS`.
+- Credential-free local checks recorded: exact Bun `1.3.10` frozen install completed twice, including an isolated cache; scoped TypeScript diagnostics `0`; external bundle diagnostics `0`; declaration audit found exactly one `Alchemy.localState()` Worker; provider effect count `0`; cleanup, hash, and worktree checks are clean.
+- Disclosed non-gating observation: the verifier's default full Bun bundle failed on missing optional native `msgpackr-extract`/`lightningcss`; temporary artifacts were removed. The scoped external-package bundle target passed. This observation yields no deploy-path or provider conclusion.
+- This evidence closes only local implementation Drift. It does not authorize or claim credentials, account/profile use, telemetry/provider effects, a Cloudflare URL, plan, deploy, reachability, rollback, destroy, or any provider action.
+
+### Provider-bound evidence (operator-owned/observed)
+
+The sanitized PR/handoff must separately contain:
+
+- the operator decision record with scope, actor, environment, action, expiry, and revocation;
+- the exact stack/stage/profile inputs, with secrets and account identifiers redacted;
+- Alchemy plan output showing exactly one Worker and no route/domain/binding/storage/state-bootstrap resource, with the `ALCHEMY_TELEMETRY_DISABLED=1` boundary observed;
+- approved Alchemy deploy output showing the one Worker and returned URL, with exact checkout/commit, stack/stage/profile, `.alchemy/` state path, and disabled-telemetry observation;
+- time-stamped HTTPS observations for `/health`, unknown route, and non-GET `/health`, including status, relevant headers, and exact synthetic body;
+- any rollback action and result, or an explicit statement that no rollback was needed for the successful run (not a claim that rollback capability was exercised);
+- exact-checkout/state telemetry-disabled destroy plan showing explicit `PreviewSpine` deletion, destroy output, post-destroy no-health observation, local-state discard, and operator revocation/expiry record;
+- a path/resource review proving no Wrangler deploy, dashboard edit, custom route/domain, production account/data, extra resource, or unlisted provider effect occurred.
+
+Provider evidence proves only the named stack/stage/action/window and the observed fixture. It does not prove production isolation beyond the recorded account/data boundary, domain laws, API/SDK parity, frontend behavior, route cutover safety, availability, performance, or release readiness. No credential, token, profile file, raw URL containing a secret, or production payload may enter the evidence artifact.
+
+## Falsifiers and definition of done
+
+### Falsifiers
+
+Any observation below falsifies this slice or enters `Drift`, even if `/health` returns `200`:
+
+- checkpoint 1 evidence is missing, superseded, or not the base used by the writer;
+- root `.env`, `.env.*`, `.dev.vars`, or `.dev.vars.*` exists, is loaded, or is inspected in the writer lane;
+- package pins use `next`, `latest`, `^`, `~`, unresolved ranges, or differ from the official source authority without a reviewed revision;
+- the current root package manager, current SDK/app manifests, or unrelated apps/packages are changed; the accepted SDK manifest must retain only `effect@4.0.0-beta.107` and no `@effect/platform` dependency, and the root lock must not introduce `effect@4.0.0-beta.102`, any platform package at a mixed beta, or more than one Effect-family version;
+- the writer runs `alchemy plan`, `alchemy deploy`, `alchemy destroy`, `alchemy login`, `alchemy dev`, Wrangler deploy, a dashboard action, or any provider/remote command;
+- any provider-bound Alchemy plan/deploy/destroy or rollback command is run without the exact `ALCHEMY_TELEMETRY_DISABLED=1` prefix, or the operator cannot record the disabled telemetry boundary and absence of unlisted telemetry;
+- the plan or deploy targets an implicit/default stage/profile, `staging`, `prod`, an unknown account, or an unrecorded environment;
+- the operator record lacks exact scope, actor, environment, action, expiry, or revocation;
+- any dummy/synthetic account ID, API token, key, credential file, or standing authority is introduced;
+- the Stack uses a provider other than Cloudflare, a state layer other than `Alchemy.localState()`, `Cloudflare.state()`, remote state, or a state-store bootstrap;
+- more or fewer than one Worker resource is planned/applied, or any binding, asset, storage, gateway, origin, service binding, Durable Object, queue, secret, route, domain, or extra state resource appears;
+- `routes`, `domain`, custom DNS, zone route, route manifest, production URL, route cutover, or public production effect appears;
+- `workersDev: { enabled: true, previewsEnabled: false }` is absent or false when no other reachability is authorized, version preview URLs are enabled, or the returned URL is not an operator-observed non-production workers.dev preview; a missing account capability must not be bypassed;
+- synthetic response body/status/headers differ from the inherited contract, an unknown route succeeds, a disallowed method succeeds, or any external data/secret is returned;
+- plan output is treated as apply evidence, deploy output is treated as journey evidence, or a deployment log is treated as domain/conformance evidence;
+- rollback or destroy is performed without recorded scope, expiry, actor, or action; `unsafe nuke` or account-wide cleanup is used;
+- the stage survives beyond `expiresAt`, the old URL still returns the health `200` after destroy settles, the destroy plan is empty/no-op when deletion is expected, or local state is discarded before remote absence is recorded;
+- capability/profile revocation is assumed rather than observed and recorded;
+- any authority conflict, source/version change, runtime disagreement, or predecessor regression is not entered as `Drift` and routed to the product lead.
+
+### Definition of done
+
+The future PR may claim this draft's journey complete only when all are observed and recorded:
+**Applicable local DoD result (2026-08-10):** Items 1–4 and the local review/evidence portions of 11–12 are complete at source HEAD `8ab3d5cc`; implementation/evidence is Building-complete and pre-freeze. Feature-lead freeze, one-to-one PR, objective journey under authority, blind-first frozen-spec gate, and provider-bound items 5–10 are not claimed.
+
+1. `0001` accepted checkpoint-1 evidence, exact implementation candidate `8a16ea999d2aa6ddd8ab0982478d701263183795`, and byte-identical `infra/preview.worker.ts` at `af069395` are linked.
+2. Local credential-file preflight, frozen install, exact version-source review, declaration check, ignore proof, and path-scope review pass without provider/remote commands.
+3. The exact root pins (`alchemy@2.0.0-beta.70`, `effect@4.0.0-beta.107`, `@effect/platform-bun@4.0.0-beta.107`, `@effect/platform-node@4.0.0-beta.107`) are present in the lockfile, the root lock contains only the one Effect-family version `4.0.0-beta.107`, and the accepted SDK remains at that same beta.107 with no `@effect/platform` dependency; an explicitly reviewed source change returns this spec through `Drift` before implementation.
+4. `alchemy.run.ts` uses the declared Stack/provider/local-state/one-Worker shape and preserves the checkpoint-1 Worker contract.
+5. An operator decision record authorizes exactly one non-production stack/stage/profile and names scope, actor, environment, plan/deploy/probe/rollback/destroy actions, expiry, and revocation.
+6. Redacted plan output shows exactly one `Cloudflare.Worker` and no extra resource, route, domain, binding, state bootstrap, production reference, or data source.
+7. Operator-approved deploy output returns one observed non-production workers.dev URL, with no production or custom route effect.
+8. The URL probe observes exact health `200` JSON/headers, unknown-route `404`, and non-GET `/health` `405`/`Allow: GET`.
+9. Any failure has an explicitly recorded operator rollback or destroy action; successful completion does not overclaim rollback exercise.
+10. Stage-scoped destroy occurs at or before expiry from the exact deploying checkout/state; the operator records the telemetry-disabled `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy destroy alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE" --dry-run` with explicit `PreviewSpine` deletion before the same-boundary `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy destroy alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE" --yes` action, and records deletion output, post-destroy no-health observation, local-state discard only after remote absence, and capability revocation/expiry.
+11. For the current local checkpoint, independent review and local verification are complete and local implementation Drift is closed, but no feature-lead freeze, one-to-one PR, objective journey under authority, or blind-first frozen-spec gate is recorded. Provider plan/deploy/reachability/rollback/destroy remain blocked on scoped operator authorization; `Experienceable` and `Conforming` are not claimed.
+12. Evidence is sanitized and limited to this journey; no credentials, PII, production data, or unreviewed account capability claim is present.
+
+## Task capsule — future bounded writer
+
+| Field | Capsule content |
+|---|---|
+| Spec ID/path | `0005`; `mono-web/design-specs/0005-cloudflare-alchemy-preview.md` |
+| Role/objective | Engineer; realize one Alchemy v2 non-production PreviewSpine deployment after checkpoint 1, preserving the synthetic Worker, and hand off local and operator-owned evidence without receiving credentials. |
+| Base/worktree | Start from exact candidate `8a16ea999d2aa6ddd8ab0982478d701263183795`; prove `infra/preview.worker.ts` is byte-identical to checkpoint-1 tip `af069395`; record commit, branch, worktree, and predecessor evidence before mutation. One writer owns this capsule; one operator owns provider actions. |
+| Mutable authority | Root `package.json`; root `bun.lock`; root `.gitignore` for `.alchemy/`; new root `alchemy.run.ts`. Generated `.alchemy/` and logs are disposable local state. Do not edit `infra/preview.worker.ts`, apps, packages, workflows, routes, docs, or authority files. |
+| Forbidden actions | Any provider/remote command by the writer; credentials/profile files; dummy values; `alchemy login`; `alchemy dev`; `alchemy plan/deploy/destroy`; Wrangler deploy/versions upload; dashboard; `Cloudflare.state()`/bootstrap; extra resources; routes/domains/DNS; production/staging; production data; SDK/backend/frontend changes; `--adopt`; `unsafe nuke`; PR/push/deploy without operator authority; silent spec/authority edits. |
+| Dependencies/conflicts | Accepted ADR 0001 §§3, 5–6, 11–16 → accepted `0001` local checkpoint evidence → this draft's independent review and product-lead acceptance → this capsule. Root pins are `alchemy@2.0.0-beta.70`, `effect@4.0.0-beta.107`, and `@effect/platform-bun`/`@effect/platform-node` at exact beta.107; the SDK's same beta.107 has no `@effect/platform` dependency. The resolved credential-free Alchemy local Drift is a predecessor constraint, not a workaround. Any predecessor regression pauses this capsule. |
+| Context/law/interface references | ADR 0001; product lead charter §§2, 4–7, 9–10, 12; lifecycle §§2, 4–10, 12; domain model as a no-law boundary; `0001` HTTP contract; official Alchemy Stack/Worker/stages/state/CLI docs; official Cloudflare workers.dev/preview/permissions docs. |
+| Exact skills | Alchemy v2/Effect deployment specification; Cloudflare Worker preview and lifecycle evidence; lifecycle capsule/Drift procedure. No provider action skill is authority to execute a command. |
+| Sensitive-data policy | No credentials, secrets, PII, production data, profile contents, or raw account identifiers. Filename-only credential preflight; operator holds the profile/capability; synthetic fixture only; sanitize URLs/output; stop on any prompt, unexpected resource, route/domain, production reference, or capability mismatch. |
+| Verification scenarios | Credential-free frozen install and exact-pin/source review; static/type declaration check; `.alchemy/` ignore proof; link/re-run checkpoint-1 local smoke only under `0001`; operator-authorized telemetry-disabled plan; one-Worker plan review; operator-approved telemetry-disabled deploy; exact health/404/405 probes; pre-authorized rollback if needed from the same checkout/state; telemetry-disabled stage-scoped destroy `--dry-run` with explicit deletion followed by same-boundary `--yes` before expiry; post-destroy no-health and revocation evidence. |
+| Exit criteria | All [Definition of done](#definition-of-done) items pass; no linked Drift; local state discarded only after remote destroy; sanitized evidence handed to the one-to-one PR/handoff; no claim beyond the observed stage and fixture. |
+| Evidence destination | Sanitized one-to-one PR evidence section and task handoff; do not add a repository evidence file or credential artifact. Operator keeps the authority record and raw secret-bearing material outside the repository. |
+| Drift path | Stop on falsifier; preserve artifact, observation, actor, stage, and time; notify product lead/operator. Return to `Specified` when intent/source/authority changes, or `Building` when implementation alone is corrected. A product lead does not resolve Drift by editing the easiest file. |
+| Cleanup | Operator uses the exact deploying checkout/state, runs `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy destroy alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE" --dry-run` and requires `PreviewSpine` deletion before the same-boundary `ALCHEMY_TELEMETRY_DISABLED=1 bun alchemy destroy alchemy.run.ts --stage "$PREVIEW_STAGE" --profile "$PREVIEW_PROFILE" --yes`, destroys the exact stack/stage before expiry, verifies no health response, discards `.alchemy/` after remote absence, revokes/expires the capability, and reports residual risk. Writer leaves no generated state or logs tracked. |
+| Operator authorization | Required before any provider/remote effect. Record scope, actor, environment, action, expiry, revocation, and the exact one-Worker resource graph. Product-lead acceptance is not operator authority. |
+
+## Official sources
+
+Primary sources reviewed for this draft on `2026-08-10`:
+
+### Repository authorities
+
+- [ADR 0001 — Cloudflare topology and migration architecture](../../docs/decisions/0001-cloudflare-topology-and-migration-architecture.md)
+- [Product lead charter](../../docs/product-lead-charter.md)
+- [Agentic development lifecycle](../../docs/agentic-development-lifecycle.md)
+- [Domain model](../../docs/domain-model.md)
+- [Accepted checkpoint 1 local preview spine](./0001-cloudflare-local-preview-spine.md)
+
+### Alchemy v2
+
+- [Getting started — exact official install command](https://alchemy.run/getting-started/#install)
+- [Alchemy Stack composition root](https://alchemy.run/infrastructure-as-code/stack/)
+- [Alchemy CLI command map](https://alchemy.run/cli/)
+- [Alchemy plan](https://alchemy.run/cli/plan/)
+- [Alchemy deploy (plan/approval/apply path)](https://alchemy.run/cli/deploy/)
+- [Alchemy destroy](https://alchemy.run/cli/destroy/)
+- [Alchemy stages](https://alchemy.run/environments/stages/)
+- [Alchemy profiles](https://alchemy.run/environments/profiles/)
+- [Alchemy state store and local/remote ownership](https://alchemy.run/state-store/)
+- [Alchemy Cloudflare Worker resource](https://alchemy.run/providers/cloudflare/workers/worker/)
+- [Alchemy local development](https://alchemy.run/environments/local-development/) — not used as credential-free checkpoint evidence
+- [Official npm `alchemy` dist-tags](https://registry.npmjs.org/alchemy)
+- [Official npm `alchemy@2.0.0-beta.70` metadata](https://registry.npmjs.org/alchemy/2.0.0-beta.70)
+
+### Cloudflare
+
+- [Workers versions and deployments](https://developers.cloudflare.com/workers/versions-and-deployments/)
+- [Workers preview URLs](https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/)
+- [Workers.dev routing surface](https://developers.cloudflare.com/workers/configuration/routing/workers-dev/)
+- [Cloudflare API token permissions](https://developers.cloudflare.com/fundamentals/api/reference/permissions/)
+- [Workers secrets](https://developers.cloudflare.com/workers/configuration/secrets/)
+
+These sources document mechanics and permission vocabulary. They do not establish that this repository's operator account has the required workers.dev surface, token scope, quota, billing, Access policy, or domain capability. Those remain explicit operator decisions and runtime observations.

--- a/infra/preview.worker.ts
+++ b/infra/preview.worker.ts
@@ -1,0 +1,29 @@
+const HEALTH_BODY =
+  '{ "service": "mono-web", "purpose": "cloudflare-local-preview-spine", "status": "ok" }';
+
+const HEALTH_HEADERS = {
+  "Content-Type": "application/json; charset=UTF-8",
+  "Cache-Control": "no-store",
+};
+
+export default {
+  fetch(request: Request) {
+    const { pathname } = new URL(request.url);
+
+    if (pathname !== "/health") {
+      return new Response(null, { status: 404 });
+    }
+
+    if (request.method !== "GET") {
+      return new Response(null, {
+        status: 405,
+        headers: { Allow: "GET" },
+      });
+    }
+
+    return new Response(HEALTH_BODY, {
+      status: 200,
+      headers: HEALTH_HEADERS,
+    });
+  },
+};

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "turbo -F @monoweb/homepage -F @monoweb/dashboard dev",
+    "preview:dev": "WRANGLER_SEND_METRICS=false WRANGLER_SEND_ERROR_REPORTS=false CLOUDFLARE_API_BASE_URL=http://127.0.0.1:0 CLOUDFLARE_CF_FETCH_ENABLED=false WRANGLER_LOG_PATH=.wrangler/logs node node_modules/wrangler/bin/wrangler.js dev infra/preview.worker.ts --local --ip 127.0.0.1 --port 8787 --compatibility-date 2026-08-08",
     "build": "turbo build",
     "check-types": "turbo check-types",
     "test": "turbo test",
@@ -17,12 +18,22 @@
     "version": "changeset version",
     "release": "changeset publish"
   },
+  "dependencies": {
+    "@effect/platform-bun": "4.0.0-beta.107",
+    "@effect/platform-node": "4.0.0-beta.107",
+    "alchemy": "2.0.0-beta.70",
+    "effect": "4.0.0-beta.107"
+  },
   "devDependencies": {
     "@changesets/cli": "^2.30.0",
     "oxfmt": "^0.26.0",
     "oxlint": "^1.41.0",
     "turbo": "^2.8.12",
-    "typescript": "^5"
+    "typescript": "^5",
+    "wrangler": "4.120.0"
+  },
+  "engines": {
+    "node": ">=22"
   },
   "packageManager": "bun@1.3.10"
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -20,11 +20,9 @@
     "release": "changeset publish"
   },
   "dependencies": {
-    "@effect/platform": "^0.96.0",
-    "effect": "^3.21.0"
+    "effect": "4.0.0-beta.107"
   },
   "devDependencies": {
-    "@effect/vitest": "^0.29.0",
     "@types/node": "^22",
     "typescript": "^5",
     "vitest": "^4.1.0"

--- a/packages/sdk/src/__tests__/adapter.test.ts
+++ b/packages/sdk/src/__tests__/adapter.test.ts
@@ -53,7 +53,7 @@ describe("parseInterviewStatus", () => {
 describe("DateFromIso", () => {
   it("decodes an ISO date string to a Date object", async () => {
     const result = await Effect.runPromise(
-      Schema.decodeUnknown(DateFromIso)("2026-01-10T12:00:00+01:00"),
+      Schema.decodeUnknownEffect(DateFromIso)("2026-01-10T12:00:00+01:00"),
     )
     expect(result).toBeInstanceOf(Date)
     expect(result.toISOString()).toContain("2026-01-10")
@@ -61,23 +61,28 @@ describe("DateFromIso", () => {
 
   it("decodes a date-only string to a Date", async () => {
     const result = await Effect.runPromise(
-      Schema.decodeUnknown(DateFromIso)("2026-03-21"),
+      Schema.decodeUnknownEffect(DateFromIso)("2026-03-21"),
     )
     expect(result).toBeInstanceOf(Date)
+  })
+  it("rejects an invalid ISO date", async () => {
+    await expect(
+      Effect.runPromise(Schema.decodeUnknownEffect(DateFromIso)("not-a-date")),
+    ).rejects.toBeDefined()
   })
 })
 
 describe("NullableDateFromIso", () => {
   it("decodes null to null", async () => {
     const result = await Effect.runPromise(
-      Schema.decodeUnknown(NullableDateFromIso)(null),
+      Schema.decodeUnknownEffect(NullableDateFromIso)(null),
     )
     expect(result).toBeNull()
   })
 
   it("decodes an ISO date string to a Date", async () => {
     const result = await Effect.runPromise(
-      Schema.decodeUnknown(NullableDateFromIso)("2026-01-10"),
+      Schema.decodeUnknownEffect(NullableDateFromIso)("2026-01-10"),
     )
     expect(result).toBeInstanceOf(Date)
   })

--- a/packages/sdk/src/__tests__/receipt-effect-v4-compatibility.test.ts
+++ b/packages/sdk/src/__tests__/receipt-effect-v4-compatibility.test.ts
@@ -1,0 +1,349 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { Cause, Effect, Exit, Fiber } from "effect"
+import { createClient, ConfigurationError, NetworkError, NotFoundError, UnauthorizedError, ValidationError, ConflictError, RateLimitedError } from "../promise.js"
+import { createEffectClient } from "../effect-client.js"
+import { apiUrl } from "../config.js"
+
+const FIXTURE_URL = "https://receipt-fixture.invalid"
+const RAILWAY_URL = "https://vektorprogrammet-production.up.railway.app"
+
+const validReceipt = {
+  id: 42,
+  visualId: "receipt-42",
+  description: "Travel to course",
+  sum: 125.5,
+  receiptDate: "2026-08-08",
+  submitDate: "2026-08-09T10:00:00Z",
+  status: "pending",
+  refundDate: null,
+  userName: "Synthetic User",
+}
+
+const validHydra = {
+  "hydra:member": [validReceipt],
+  "hydra:totalItems": 1,
+}
+
+type RecordedRequest = { url: string; init: RequestInit }
+
+function makeResponse(status: number, body?: unknown, parse = true): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: parse
+      ? () => Promise.resolve(body)
+      : () => {
+          throw new Error("response.json() must not be called")
+        },
+  } as unknown as Response
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  return typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+}
+
+function header(init: RequestInit | undefined, name: string): string | undefined {
+  const headers = init?.headers
+  if (headers instanceof Headers) return headers.get(name) ?? undefined
+  if (headers === undefined) return undefined
+  const record = headers as Record<string, string>
+  return record[name] ?? record[name.toLowerCase()]
+}
+
+function expectMethods(domain: object, names: readonly string[]): void {
+  for (const name of names) {
+    expect(typeof (domain as Record<string, unknown>)[name]).toBe("function")
+  }
+}
+
+describe("Effect v4 Receipt compatibility", () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  let requests: RecordedRequest[]
+
+  beforeEach(() => {
+    requests = []
+    fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("keeps both public entrypoints, namespaces, verbs, and execution shapes", async () => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({ url: requestUrl(input), init: init ?? {} })
+      return makeResponse(200, validHydra)
+    })
+
+    const promiseClient = createClient(FIXTURE_URL, { auth: "trace-token" })
+    const effectClient = createEffectClient(FIXTURE_URL, { auth: "trace-token" })
+
+    for (const client of [promiseClient, effectClient]) {
+      expect(client).toHaveProperty("auth")
+      expect(client).toHaveProperty("me")
+      expect(client).toHaveProperty("receipts")
+      expect(client).toHaveProperty("admin")
+      expect(client).toHaveProperty("public")
+      expect(client).toHaveProperty("context")
+      expectMethods(client.auth, ["login", "resetPassword", "setPassword"])
+      expectMethods(client.me, ["profile", "dashboard", "updateProfile"])
+      expectMethods(client.receipts, ["list", "create", "update", "delete"])
+      expectMethods(client.admin.receipts, ["list", "approve", "reject", "reopen"])
+      expectMethods(client.admin.applications, ["list", "get", "delete", "bulkDelete"])
+      expectMethods(client.admin.interviews, ["list", "assign", "schedule", "conduct", "cancel", "schemas"])
+      expectMethods(client.admin.users, ["list"])
+      expectMethods(client.admin.scheduling, ["assistants", "schools", "substitutes"])
+      expectMethods(client.admin.teams, ["list", "interest"])
+      expectMethods(client.admin, ["mailingLists", "admissionStats"])
+      expectMethods(client.public, ["departments", "fieldOfStudies", "sponsors", "teams"])
+    }
+
+    const promiseResult = promiseClient.admin.receipts.list({ status: "pending", page: 1, pageSize: 2 })
+    expect(typeof promiseResult.then).toBe("function")
+    await promiseResult
+
+    const effectResult = effectClient.admin.receipts.list({ status: "pending", page: 1, pageSize: 2 })
+    expect(Effect.isEffect(effectResult)).toBe(true)
+    await Effect.runPromise(effectResult)
+  })
+
+  it("exports undefined apiUrl without absent-env module side effects", async () => {
+    const originalApiUrl = process.env.API_URL
+    const originalViteApiUrl = process.env.VITE_API_URL
+    try {
+      delete process.env.API_URL
+      delete process.env.VITE_API_URL
+      vi.resetModules()
+      // Deliberately reload the known module to exercise evaluation with both env inputs absent.
+      const imported = await import("../config.js")
+      expect(imported.apiUrl).toBeUndefined()
+      expect(fetchMock).not.toHaveBeenCalled()
+      expect(apiUrl).not.toBe(RAILWAY_URL)
+    } finally {
+      if (originalApiUrl === undefined) delete process.env.API_URL
+      else process.env.API_URL = originalApiUrl
+      if (originalViteApiUrl === undefined) delete process.env.VITE_API_URL
+      else process.env.VITE_API_URL = originalViteApiUrl
+      vi.resetModules()
+    }
+  })
+
+  it("fails configuration inside the operation without calling fetch", async () => {
+    const promiseClient = createClient(undefined)
+    const effectClient = createEffectClient(undefined)
+    expect(() => createClient(undefined)).not.toThrow()
+    expect(() => createEffectClient(undefined)).not.toThrow()
+
+    const promiseError = await promiseClient.admin.receipts.list().catch((error: unknown) => error)
+    expect(promiseError).toBeInstanceOf(ConfigurationError)
+    expect(promiseError).toMatchObject({ type: "configuration" })
+
+    const effectError = await Effect.runPromise(Effect.flip(effectClient.admin.receipts.list()))
+    expect(effectError).toMatchObject({ _tag: "Configuration" })
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(requests.some(({ url }) => url.includes(RAILWAY_URL))).toBe(false)
+
+    const invalidPromise = createClient("not-a-url")
+    const invalidEffect = createEffectClient("not-a-url")
+    await expect(invalidPromise.admin.receipts.list()).rejects.toMatchObject({ type: "configuration" })
+    const invalidEffectError = await Effect.runPromise(Effect.flip(invalidEffect.admin.receipts.list()))
+    expect(invalidEffectError).toMatchObject({ _tag: "Configuration" })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("authenticates and strictly decodes the Promise Receipt list", async () => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({ url: requestUrl(input), init: init ?? {} })
+      return makeResponse(200, validHydra)
+    })
+    const client = createClient(FIXTURE_URL, { auth: "trace-token" })
+
+    const result = await client.admin.receipts.list({ status: "pending", page: 1, pageSize: 2 })
+    expect(result).toMatchObject({ items: [expect.anything()], totalItems: 1, page: 1, pageSize: 2 })
+    const item = result.items[0]!
+    expect(item).toMatchObject({
+      id: 42,
+      visualId: "receipt-42",
+      description: "Travel to course",
+      sum: 125.5,
+      status: "pending",
+      refundDate: null,
+      userName: "Synthetic User",
+    })
+    expect(item.receiptDate).toBeInstanceOf(Date)
+    expect(item.submitDate).toBeInstanceOf(Date)
+    expect(item.receiptDate.toISOString()).toContain("2026-08-08")
+    expect(item.submitDate.toISOString()).toBe("2026-08-09T10:00:00.000Z")
+
+    expect(requests[0]?.url).toBe(`${FIXTURE_URL}/api/admin/receipts?status=pending&page=1&itemsPerPage=2`)
+    expect(header(requests[0]?.init, "Accept")).toBe("application/ld+json")
+    expect(header(requests[0]?.init, "Authorization")).toBe("Bearer trace-token")
+  })
+
+  it("returns a direct Effect list value with the same Page-compatible result", async () => {
+    fetchMock.mockResolvedValue(makeResponse(200, validHydra))
+    const client = createEffectClient(FIXTURE_URL, { auth: "trace-token" })
+    const effect = client.admin.receipts.list({ status: "pending", page: 1, pageSize: 2 })
+    expect(Effect.isEffect(effect)).toBe(true)
+
+    const result = await Effect.runPromise(effect)
+    expect(result).toMatchObject({ totalItems: 1, page: 1, pageSize: 2 })
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0]?.receiptDate).toBeInstanceOf(Date)
+    expect(result.items[0]?.submitDate).toBeInstanceOf(Date)
+  })
+
+  it("maps approve to refunded and treats 204 as void without parsing JSON", async () => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({ url: requestUrl(input), init: init ?? {} })
+      return makeResponse(204, undefined, false)
+    })
+    const promiseClient = createClient(FIXTURE_URL, { auth: "trace-token" })
+    await expect(promiseClient.admin.receipts.approve(42)).resolves.toBeUndefined()
+    expect(requests[0]?.url).toBe(`${FIXTURE_URL}/api/admin/receipts/42/status`)
+    expect(requests[0]?.init.method).toBe("PUT")
+    expect(header(requests[0]?.init, "Authorization")).toBe("Bearer trace-token")
+    expect(JSON.parse(String(requests[0]?.init.body))).toEqual({ status: "refunded" })
+
+    requests = []
+    const effectClient = createEffectClient(FIXTURE_URL, { auth: "trace-token" })
+    const effect = effectClient.admin.receipts.approve(42)
+    expect(Effect.isEffect(effect)).toBe(true)
+    await expect(Effect.runPromise(effect)).resolves.toBeUndefined()
+    expect(requests[0]?.url).toBe(`${FIXTURE_URL}/api/admin/receipts/42/status`)
+    expect(requests[0]?.init.method).toBe("PUT")
+    expect(JSON.parse(String(requests[0]?.init.body))).toEqual({ status: "refunded" })
+  })
+
+  it("rejects malformed Hydra envelopes, members, and ISO dates before exposing values", async () => {
+    const malformedBodies = [
+      { "hydra:totalItems": 1 },
+      { "hydra:member": { id: 42 }, "hydra:totalItems": 1 },
+      { "hydra:member": [{ ...validReceipt, userName: undefined }], "hydra:totalItems": 1 },
+      { "hydra:member": [{ ...validReceipt, receiptDate: "not-a-date" }], "hydra:totalItems": 1 },
+    ]
+
+    for (const body of malformedBodies) {
+      fetchMock.mockResolvedValue(makeResponse(200, body))
+      const promiseClient = createClient(FIXTURE_URL)
+      const promiseError = await promiseClient.admin.receipts.list().catch((error: unknown) => error)
+      expect(promiseError).toBeInstanceOf(ValidationError)
+      expect(promiseError).toMatchObject({ type: "validation" })
+
+      const effectClient = createEffectClient(FIXTURE_URL)
+      const effectError = await Effect.runPromise(Effect.flip(effectClient.admin.receipts.list()))
+      expect(effectError).toMatchObject({ _tag: "Validation" })
+    }
+  })
+
+  it("preserves typed HTTP and network error mappings on both surfaces", async () => {
+    const cases = [
+      [401, UnauthorizedError, "unauthorized", "Unauthorized"] as const,
+      [403, UnauthorizedError, "unauthorized", "Unauthorized"] as const,
+      [404, NotFoundError, "not_found", "NotFound"] as const,
+      [409, ConflictError, "conflict", "Conflict"] as const,
+      [422, ValidationError, "validation", "Validation"] as const,
+      [429, RateLimitedError, "rate_limited", "RateLimited"] as const,
+      [500, NetworkError, "network", "Network"] as const,
+    ]
+
+    for (const [status, publicError, publicType, effectTag] of cases) {
+      const body = status === 422
+        ? { violations: [{ propertyPath: "description", message: "Too short" }] }
+        : {}
+      fetchMock.mockResolvedValue(makeResponse(status, body))
+      const promiseClient = createClient(FIXTURE_URL)
+      const promiseError = await promiseClient.admin.receipts.list().catch((error: unknown) => error)
+      expect(promiseError).toBeInstanceOf(publicError)
+      expect(promiseError).toMatchObject({ type: publicType })
+      if (status === 422) expect(promiseError).toMatchObject({ fields: { description: "Too short" } })
+
+      const effectClient = createEffectClient(FIXTURE_URL)
+      const effectError = await Effect.runPromise(Effect.flip(effectClient.admin.receipts.list()))
+      expect(effectError).toMatchObject({ _tag: effectTag })
+      if (status === 422) expect(effectError).toMatchObject({ fields: { description: "Too short" } })
+    }
+
+    fetchMock.mockRejectedValue(new TypeError("Failed to fetch"))
+    const promiseNetworkError = await createClient(FIXTURE_URL).admin.receipts.list().catch((error: unknown) => error)
+    expect(promiseNetworkError).toBeInstanceOf(NetworkError)
+    expect(promiseNetworkError).toMatchObject({ type: "network" })
+    const effectNetworkError = await Effect.runPromise(Effect.flip(createEffectClient(FIXTURE_URL).admin.receipts.list()))
+    expect(effectNetworkError).toMatchObject({ _tag: "Network" })
+  })
+
+  it("resolves async auth for each request without changing the public seam", async () => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({ url: requestUrl(input), init: init ?? {} })
+      return makeResponse(200, validHydra)
+    })
+    const auth = vi.fn().mockResolvedValue("trace-token")
+    const client = createClient(FIXTURE_URL, { auth })
+
+    await client.admin.receipts.list()
+    await client.admin.receipts.list()
+
+    expect(auth).toHaveBeenCalledTimes(2)
+    expect(header(requests[0]?.init, "Authorization")).toBe("Bearer trace-token")
+    expect(header(requests[1]?.init, "Authorization")).toBe("Bearer trace-token")
+  })
+
+  it("propagates fiber interruption to fetch and leaves no owned request work", async () => {
+    let resolveStarted!: () => void
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve
+    })
+    let receivedSignal: AbortSignal | undefined
+    let activeRequests = 0
+    let abortObservations = 0
+    let completionObservations = 0
+    let listenerActive = false
+
+    fetchMock.mockImplementation((_input: RequestInfo | URL, init?: RequestInit) => {
+      activeRequests += 1
+      receivedSignal = init?.signal ?? undefined
+      resolveStarted()
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal
+        if (signal === undefined) {
+          activeRequests -= 1
+          reject(new Error("missing abort signal"))
+          return
+        }
+        let settled = false
+        const onAbort = () => {
+          if (settled) return
+          settled = true
+          listenerActive = false
+          activeRequests -= 1
+          abortObservations += 1
+          signal.removeEventListener("abort", onAbort)
+          reject(new Error("aborted"))
+        }
+        listenerActive = true
+        signal.addEventListener("abort", onAbort, { once: true })
+      }).then((response) => {
+        completionObservations += 1
+        return response
+      })
+    })
+
+    const client = createEffectClient(FIXTURE_URL)
+    const fiber = Effect.runFork(client.admin.receipts.list())
+    await started
+    await Effect.runPromise(Fiber.interrupt(fiber))
+    const ownerExit = await Effect.runPromise(Fiber.await(fiber))
+
+    expect(receivedSignal).toBeInstanceOf(AbortSignal)
+    expect(receivedSignal?.aborted).toBe(true)
+    expect(abortObservations).toBe(1)
+    expect(activeRequests).toBe(0)
+    expect(completionObservations).toBe(0)
+    expect(listenerActive).toBe(false)
+    expect(Exit.isFailure(ownerExit)).toBe(true)
+    if (Exit.isFailure(ownerExit)) {
+      expect(Cause.hasInterruptsOnly(ownerExit.cause)).toBe(true)
+    }
+  })
+})

--- a/packages/sdk/src/__tests__/schemas.test.ts
+++ b/packages/sdk/src/__tests__/schemas.test.ts
@@ -22,7 +22,7 @@ const rawReceipt = {
 describe("Receipt", () => {
   it("decodes from raw API shape", async () => {
     const result = await Effect.runPromise(
-      Schema.decodeUnknown(Receipt)(rawReceipt),
+      Schema.decodeUnknownEffect(Receipt)(rawReceipt),
     )
     expect(result).toBeInstanceOf(Receipt)
     expect(result.id).toBe(1)
@@ -34,7 +34,7 @@ describe("Receipt", () => {
 
   it("encodes back to raw API shape (round-trip)", async () => {
     const decoded = await Effect.runPromise(
-      Schema.decodeUnknown(Receipt)(rawReceipt),
+      Schema.decodeUnknownEffect(Receipt)(rawReceipt),
     )
     const encoded = Schema.encodeSync(Receipt)(decoded)
     expect(typeof encoded.receiptDate).toBe("string")
@@ -44,21 +44,21 @@ describe("Receipt", () => {
 
   it("isPending returns true when status is 'pending'", async () => {
     const receipt = await Effect.runPromise(
-      Schema.decodeUnknown(Receipt)(rawReceipt),
+      Schema.decodeUnknownEffect(Receipt)(rawReceipt),
     )
     expect(receipt.isPending).toBe(true)
   })
 
   it("isPending returns false when status is 'refunded'", async () => {
     const receipt = await Effect.runPromise(
-      Schema.decodeUnknown(Receipt)({ ...rawReceipt, status: "refunded" }),
+      Schema.decodeUnknownEffect(Receipt)({ ...rawReceipt, status: "refunded" }),
     )
     expect(receipt.isPending).toBe(false)
   })
 
   it("formattedAmount returns '<sum> kr'", async () => {
     const receipt = await Effect.runPromise(
-      Schema.decodeUnknown(Receipt)(rawReceipt),
+      Schema.decodeUnknownEffect(Receipt)(rawReceipt),
     )
     expect(receipt.formattedAmount).toBe("150 kr")
   })
@@ -78,7 +78,7 @@ const rawApplication = {
 describe("Application (ApplicationFromRaw)", () => {
   it("decodes from raw API shape with integer status", async () => {
     const result = await Effect.runPromise(
-      Schema.decodeUnknown(ApplicationFromRaw)(rawApplication),
+      Schema.decodeUnknownEffect(ApplicationFromRaw)(rawApplication),
     )
     expect(result.status).toBe("received")
     expect(result.id).toBe(42)
@@ -87,7 +87,7 @@ describe("Application (ApplicationFromRaw)", () => {
 
   it("encodes back (round-trip)", async () => {
     const decoded = await Effect.runPromise(
-      Schema.decodeUnknown(ApplicationFromRaw)(rawApplication),
+      Schema.decodeUnknownEffect(ApplicationFromRaw)(rawApplication),
     )
     const encoded = Schema.encodeSync(ApplicationFromRaw)(decoded)
     expect(typeof encoded.applicationStatus).toBe("number")
@@ -96,7 +96,7 @@ describe("Application (ApplicationFromRaw)", () => {
 
   it("statusLabel returns a non-empty Norwegian label", async () => {
     const result = await Effect.runPromise(
-      Schema.decodeUnknown(ApplicationFromRaw)(rawApplication),
+      Schema.decodeUnknownEffect(ApplicationFromRaw)(rawApplication),
     )
     expect(typeof result.statusLabel).toBe("string")
     expect(result.statusLabel.length).toBeGreaterThan(0)

--- a/packages/sdk/src/adapter/dates.ts
+++ b/packages/sdk/src/adapter/dates.ts
@@ -1,30 +1,36 @@
 /**
- * ISO date string -> Date parsing for Schema.transform pipelines.
+ * ISO date string -> Date parsing for Schema.decodeTo pipelines.
  */
 
-import { Schema } from "effect"
+import { Schema, SchemaGetter } from "effect"
+
+const ValidIsoDateString = Schema.String.pipe(
+  Schema.check(
+    Schema.makeFilter(
+      (value: string) => !Number.isNaN(new Date(value).getTime()),
+      { message: "a valid ISO date string" },
+    ),
+  ),
+)
 
 /**
  * Schema transform: ISO date string from API -> JavaScript Date.
  * Accepts full ISO 8601 ("2026-01-10T12:00:00+01:00") or date-only ("2026-01-10").
+ * Invalid dates are rejected before the Date representation is constructed.
  */
-export const DateFromIso = Schema.transform(
-  Schema.String,
-  Schema.DateFromSelf,
-  {
-    decode: (s) => new Date(s),
-    encode: (d) => d.toISOString(),
-  },
+export const DateFromIso = ValidIsoDateString.pipe(
+  Schema.decodeTo(Schema.Date, {
+    decode: SchemaGetter.transform((s: string) => new Date(s)),
+    encode: SchemaGetter.transform((d: Date) => d.toISOString()),
+  }),
 )
 
 /**
  * Nullable variant -- null stays null, string becomes Date.
  */
-export const NullableDateFromIso = Schema.transform(
-  Schema.NullOr(Schema.String),
-  Schema.NullOr(Schema.DateFromSelf),
-  {
-    decode: (s) => (s === null ? null : new Date(s)),
-    encode: (d) => (d === null ? null : d.toISOString()),
-  },
+export const NullableDateFromIso = Schema.NullOr(ValidIsoDateString).pipe(
+  Schema.decodeTo(Schema.NullOr(Schema.Date), {
+    decode: SchemaGetter.transform((s: string | null) => (s === null ? null : new Date(s))),
+    encode: SchemaGetter.transform((d: Date | null) => (d === null ? null : d.toISOString())),
+  }),
 )

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -1,13 +1,12 @@
-const DEFAULT_API_URL = "https://vektorprogrammet-production.up.railway.app";
-
-// Server-side: process.env.API_URL, Client-side: import.meta.env.VITE_API_URL
-export const apiUrl: string =
-  (typeof process !== "undefined" && process.env?.API_URL) ||
-  (typeof import.meta !== "undefined" && import.meta.env?.VITE_API_URL) ||
-  DEFAULT_API_URL;
+// Server-side: process.env.API_URL, Client-side: import.meta.env.VITE_API_URL.
+// Configuration is deliberately explicit: an absent value is not replaced with
+// a production destination. Client operations validate the base URL lazily.
+export const apiUrl: string | undefined =
+  (typeof process !== "undefined" ? process.env?.API_URL : undefined) ??
+  (typeof import.meta !== "undefined" ? import.meta.env?.VITE_API_URL : undefined)
 
 export const isFixtureMode: boolean =
   (typeof process !== "undefined" && process.env?.API_MODE === "fixture") ||
   (typeof import.meta !== "undefined" &&
     import.meta.env?.VITE_API_MODE === "fixture") ||
-  false;
+  false

--- a/packages/sdk/src/domains/admin/receipts.ts
+++ b/packages/sdk/src/domains/admin/receipts.ts
@@ -2,9 +2,10 @@ import { Effect } from "effect"
 import type { Transport } from "../../transport.js"
 import type { InternalSdkError } from "../../errors.js"
 import { AdminReceipt } from "../../schemas/receipt.js"
+import type { Page } from "../../schemas/common.js"
 
 export interface AdminReceiptsDomain {
-  list(params?: { status?: string; page?: number; pageSize?: number }): Effect.Effect<{ items: AdminReceipt[]; totalItems: number }, InternalSdkError>
+  list(params?: { status?: string; page?: number; pageSize?: number }): Effect.Effect<Page<AdminReceipt>, InternalSdkError>
   approve(id: number): Effect.Effect<void, InternalSdkError>
   reject(id: number): Effect.Effect<void, InternalSdkError>
   reopen(id: number): Effect.Effect<void, InternalSdkError>

--- a/packages/sdk/src/effect-client.ts
+++ b/packages/sdk/src/effect-client.ts
@@ -51,7 +51,7 @@ export type ClientOptions = {
 
 // --- Effect client factory ---
 
-export function createEffectClient(baseUrl: string, options?: ClientOptions) {
+export function createEffectClient(baseUrl: string | undefined, options?: ClientOptions) {
   const transport = createTransport(baseUrl, options?.auth)
   const initialToken = typeof options?.auth === "string" ? options.auth : undefined
   const context = createContext(initialToken)

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -16,6 +16,7 @@ export type SdkErrorType =
   | "conflict"
   | "network"
   | "rate_limited"
+  | "configuration"
 
 export class SdkError extends Error {
   readonly type: SdkErrorType
@@ -75,6 +76,13 @@ export class RateLimitedError extends SdkError {
   }
 }
 
+export class ConfigurationError extends SdkError {
+  constructor(message = "Invalid API URL") {
+    super("configuration", message)
+    this.name = "ConfigurationError"
+  }
+}
+
 // --- Internal Effect TaggedErrors ---
 
 export class Unauthorized extends Schema.TaggedError<Unauthorized>()(
@@ -91,7 +99,7 @@ export class Validation extends Schema.TaggedError<Validation>()(
   "Validation",
   {
     message: Schema.String,
-    fields: Schema.Record({ key: Schema.String, value: Schema.String }),
+    fields: Schema.Record(Schema.String, Schema.String),
   },
 ) {}
 
@@ -110,6 +118,11 @@ export class RateLimited extends Schema.TaggedError<RateLimited>()(
   { message: Schema.String },
 ) {}
 
+export class Configuration extends Schema.TaggedError<Configuration>()(
+  "Configuration",
+  { message: Schema.String },
+) {}
+
 export type InternalSdkError =
   | Unauthorized
   | NotFound
@@ -117,6 +130,7 @@ export type InternalSdkError =
   | Conflict
   | Network
   | RateLimited
+  | Configuration
 
 /**
  * Maps an internal Effect TaggedError to a public SdkError subclass.
@@ -136,5 +150,7 @@ export function toSdkError(error: InternalSdkError): SdkError {
       return new NetworkError(error.message, error.cause)
     case "RateLimited":
       return new RateLimitedError(error.message)
+    case "Configuration":
+      return new ConfigurationError(error.message)
   }
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -11,7 +11,9 @@ export {
   ConflictError,
   NetworkError,
   RateLimitedError,
+  ConfigurationError,
 } from "./errors.js"
+export type { SdkErrorType } from "./errors.js"
 
 // Domain types (re-exported from Schema classes)
 export type { Receipt, AdminReceipt, ReceiptInput } from "./schemas/receipt.js"

--- a/packages/sdk/src/promise.ts
+++ b/packages/sdk/src/promise.ts
@@ -34,7 +34,9 @@ export {
   ConflictError,
   NetworkError,
   RateLimitedError,
+  ConfigurationError,
 } from "./errors.js"
+export type { SdkErrorType } from "./errors.js"
 
 export type { Receipt, AdminReceipt, ReceiptInput } from "./schemas/receipt.js"
 export type { Application, ApplicationDetail } from "./schemas/application.js"
@@ -88,8 +90,7 @@ function promisifyDomain<T extends object>(
 }
 
 // --- Client factory ---
-
-export function createClient(baseUrl: string, options?: ClientOptions) {
+export function createClient(baseUrl: string | undefined, options?: ClientOptions) {
   const transport = createTransport(baseUrl, options?.auth)
   const initialToken = typeof options?.auth === "string" ? options.auth : undefined
   const context = createContext(initialToken)

--- a/packages/sdk/src/schemas/application.ts
+++ b/packages/sdk/src/schemas/application.ts
@@ -3,10 +3,10 @@
  * into a typed string enum using adapter/status.ts.
  */
 
-import { Schema } from "effect"
+import { Schema, SchemaGetter } from "effect"
 import { parseApplicationStatus } from "../adapter/status.js"
 
-export const ApplicationStatus = Schema.Literal(
+export const ApplicationStatus = Schema.Literals([
   "not_received",
   "received",
   "invited",
@@ -14,7 +14,7 @@ export const ApplicationStatus = Schema.Literal(
   "completed",
   "assigned",
   "cancelled",
-)
+])
 export type ApplicationStatus = Schema.Schema.Type<typeof ApplicationStatus>
 
 /**
@@ -61,16 +61,19 @@ export class Application extends Schema.Class<Application>("Application")({
 /**
  * Transform: raw API response (integer status) → Application (string status).
  */
-export const ApplicationFromRaw = Schema.transform(
-  RawApplication,
-  Application,
-  {
-    strict: false,
-    decode: (raw) => ({
-      ...raw,
+export const ApplicationFromRaw = RawApplication.pipe(
+  Schema.decodeTo(Application, {
+    decode: SchemaGetter.transform((raw: Schema.Schema.Type<typeof RawApplication>) => ({
+      id: raw.id,
+      userName: raw.userName,
+      userEmail: raw.userEmail,
       status: parseApplicationStatus(raw.applicationStatus),
-    }),
-    encode: (app) => ({
+      interviewStatus: raw.interviewStatus,
+      interviewer: raw.interviewer,
+      interviewScheduled: raw.interviewScheduled,
+      previousParticipation: raw.previousParticipation,
+    })),
+    encode: SchemaGetter.transform((app) => ({
       id: app.id,
       userName: app.userName,
       userEmail: app.userEmail,
@@ -79,8 +82,8 @@ export const ApplicationFromRaw = Schema.transform(
       interviewer: app.interviewer,
       interviewScheduled: app.interviewScheduled,
       previousParticipation: app.previousParticipation,
-    }),
-  },
+    })),
+  }),
 )
 
 /**
@@ -109,16 +112,19 @@ const RawApplicationDetail = Schema.Struct({
   previousParticipation: Schema.Boolean,
 })
 
-export const ApplicationDetailFromRaw = Schema.transform(
-  RawApplicationDetail,
-  ApplicationDetail,
-  {
-    strict: false,
-    decode: (raw) => ({
-      ...raw,
+export const ApplicationDetailFromRaw = RawApplicationDetail.pipe(
+  Schema.decodeTo(ApplicationDetail, {
+    decode: SchemaGetter.transform((raw: Schema.Schema.Type<typeof RawApplicationDetail>) => ({
+      id: raw.id,
+      userName: raw.userName,
+      userEmail: raw.userEmail,
       status: parseApplicationStatus(raw.applicationStatus),
-    }),
-    encode: (app) => ({
+      interviewStatus: raw.interviewStatus,
+      interviewer: raw.interviewer,
+      interviewScheduled: raw.interviewScheduled,
+      previousParticipation: raw.previousParticipation,
+    })),
+    encode: SchemaGetter.transform((app) => ({
       id: app.id,
       userName: app.userName,
       userEmail: app.userEmail,
@@ -127,6 +133,6 @@ export const ApplicationDetailFromRaw = Schema.transform(
       interviewer: app.interviewer,
       interviewScheduled: app.interviewScheduled,
       previousParticipation: app.previousParticipation,
-    }),
-  },
+    })),
+  }),
 )

--- a/packages/sdk/src/schemas/interview.ts
+++ b/packages/sdk/src/schemas/interview.ts
@@ -3,16 +3,16 @@
  * into a typed string enum using adapter/status.ts.
  */
 
-import { Schema } from "effect"
+import { Schema, SchemaGetter } from "effect"
 import { parseInterviewStatus } from "../adapter/status.js"
 
-export const InterviewSchedulingStatus = Schema.Literal(
+export const InterviewSchedulingStatus = Schema.Literals([
   "pending",
   "accepted",
   "request_new_time",
   "cancelled",
   "no_contact",
-)
+])
 export type InterviewSchedulingStatus = Schema.Schema.Type<typeof InterviewSchedulingStatus>
 
 /**
@@ -48,16 +48,20 @@ export class Interview extends Schema.Class<Interview>("Interview")({
 /**
  * Transform: raw API response (integer schedulingStatus) → Interview (string schedulingStatus).
  */
-export const InterviewFromRaw = Schema.transform(
-  RawInterview,
-  Interview,
-  {
-    strict: false,
-    decode: (raw) => ({
-      ...raw,
+export const InterviewFromRaw = RawInterview.pipe(
+  Schema.decodeTo(Interview, {
+    decode: SchemaGetter.transform((raw: Schema.Schema.Type<typeof RawInterview>) => ({
+      id: raw.id,
+      applicationId: raw.applicationId,
+      interviewerId: raw.interviewerId,
+      interviewerName: raw.interviewerName,
       schedulingStatus: parseInterviewStatus(raw.schedulingStatus),
-    }),
-    encode: (interview) => ({
+      interviewTime: raw.interviewTime,
+      room: raw.room,
+      campus: raw.campus,
+      schemaId: raw.schemaId,
+    })),
+    encode: SchemaGetter.transform((interview) => ({
       id: interview.id,
       applicationId: interview.applicationId,
       interviewerId: interview.interviewerId,
@@ -67,8 +71,8 @@ export const InterviewFromRaw = Schema.transform(
       room: interview.room,
       campus: interview.campus,
       schemaId: interview.schemaId,
-    }),
-  },
+    })),
+  }),
 )
 
 /**

--- a/packages/sdk/src/schemas/receipt.ts
+++ b/packages/sdk/src/schemas/receipt.ts
@@ -8,7 +8,7 @@ export class Receipt extends Schema.Class<Receipt>("Receipt")({
   sum: Schema.Number,
   receiptDate: DateFromIso,
   submitDate: DateFromIso,
-  status: Schema.Literal("pending", "refunded", "rejected"),
+  status: Schema.Literals(["pending", "refunded", "rejected"]),
   refundDate: NullableDateFromIso,
 }) {
   get isPending() { return this.status === "pending" }
@@ -22,15 +22,24 @@ export class AdminReceipt extends Schema.Class<AdminReceipt>("AdminReceipt")({
   sum: Schema.Number,
   receiptDate: DateFromIso,
   submitDate: DateFromIso,
-  status: Schema.Literal("pending", "refunded", "rejected"),
+  status: Schema.Literals(["pending", "refunded", "rejected"]),
   refundDate: NullableDateFromIso,
   userName: Schema.String,
 }) {}
 
 export class ReceiptInput extends Schema.Class<ReceiptInput>("ReceiptInput")({
-  description: Schema.String.pipe(Schema.nonEmptyString(), Schema.maxLength(5000)),
-  sum: Schema.Number.pipe(Schema.positive()),
-  receiptDate: Schema.String.pipe(Schema.pattern(/^\d{4}-\d{2}-\d{2}$/)),
+  description: Schema.String.pipe(
+    Schema.check(Schema.isMinLength(1), Schema.isMaxLength(5000)),
+  ),
+  sum: Schema.Number.pipe(Schema.check(Schema.isGreaterThan(0))),
+  receiptDate: Schema.String.pipe(
+    Schema.check(
+      Schema.makeFilter(
+        (value: string) => /^\d{4}-\d{2}-\d{2}$/.test(value),
+        { message: "a YYYY-MM-DD date string" },
+      ),
+    ),
+  ),
 }) {}
 
 export class ReceiptCreateResponse extends Schema.Class<ReceiptCreateResponse>("ReceiptCreateResponse")({

--- a/packages/sdk/src/schemas/scheduling.ts
+++ b/packages/sdk/src/schemas/scheduling.ts
@@ -6,7 +6,7 @@ export class SchedulingAssistant extends Schema.Class<SchedulingAssistant>("Sche
   email: Schema.String,
   doublePosition: Schema.NullOr(Schema.Boolean),
   preferredGroup: Schema.NullOr(Schema.Number),
-  availability: Schema.Record({ key: Schema.String, value: Schema.Boolean }),
+  availability: Schema.Record(Schema.String, Schema.Boolean),
   score: Schema.NullOr(Schema.Number),
   suitability: Schema.NullOr(Schema.String),
   previousParticipation: Schema.NullOr(Schema.Boolean),
@@ -16,7 +16,7 @@ export class SchedulingAssistant extends Schema.Class<SchedulingAssistant>("Sche
 export class SchedulingSchool extends Schema.Class<SchedulingSchool>("SchedulingSchool")({
   id: Schema.Number,
   name: Schema.String,
-  capacity: Schema.Array(Schema.Record({ key: Schema.String, value: Schema.Number })),
+  capacity: Schema.Array(Schema.Record(Schema.String, Schema.Number)),
 }) {}
 
 export class Substitute extends Schema.Class<Substitute>("Substitute")({

--- a/packages/sdk/src/transport.ts
+++ b/packages/sdk/src/transport.ts
@@ -7,44 +7,59 @@
 
 import { Effect, Schema, pipe } from "effect"
 import {
-  Unauthorized, NotFound, Validation, Conflict, Network, RateLimited,
+  Unauthorized,
+  NotFound,
+  Validation,
+  Conflict,
+  Network,
+  RateLimited,
+  Configuration,
   type InternalSdkError,
 } from "./errors.js"
 import { parseViolations } from "./adapter/errors.js"
 
 export type AuthOption = string | (() => string | Promise<string>)
+export type QueryParams = Record<string, string | number | undefined>
 
 /**
  * Resolves the auth token — supports static string or async function.
  */
-const resolveAuth = (auth: AuthOption): Effect.Effect<string> =>
+const resolveAuth = (auth: AuthOption): Effect.Effect<string, Network> =>
   typeof auth === "string"
     ? Effect.succeed(auth)
-    : Effect.promise(async () => {
-        return auth()
+    : Effect.tryPromise({
+        try: () => Promise.resolve(auth()),
+        catch: (cause) =>
+          new Network({
+            message: cause instanceof Error ? cause.message : "Failed to resolve auth",
+            cause,
+          }),
       })
 
 /**
  * Maps HTTP status codes to InternalSdkError.
  */
-const mapStatusToError = (status: number, _body: unknown): InternalSdkError => {
-  // TODO: 403 should map to a separate ForbiddenError rather than Unauthorized
+const mapStatusToError = (status: number, body: unknown): InternalSdkError => {
   if (status === 401 || status === 403) return new Unauthorized({ message: `HTTP ${status}` })
   if (status === 404) return new NotFound({ message: "Not found" })
   if (status === 409) return new Conflict({ message: "Conflict" })
-  if (status === 422) return new Validation({ message: "Validation failed", fields: parseViolations(_body) })
+  if (status === 422) return new Validation({ message: "Validation failed", fields: parseViolations(body) })
   if (status === 429) return new RateLimited({ message: "Rate limited" })
   return new Network({ message: `HTTP ${status}` })
 }
 
 export interface Transport {
-  get<A, I>(url: string, schema: Schema.Schema<A, I>, params?: Record<string, string | number | undefined>): Effect.Effect<A, InternalSdkError>
-  getCollection<A, I>(url: string, itemSchema: Schema.Schema<A, I>, params?: Record<string, string | number | undefined>): Effect.Effect<{ items: A[], totalItems: number, page: number, pageSize: number }, InternalSdkError>
-  post<A, I>(url: string, body: unknown, schema: Schema.Schema<A, I>): Effect.Effect<A, InternalSdkError>
+  get<A>(url: string, schema: Schema.ConstraintDecoder<A, never>, params?: QueryParams): Effect.Effect<A, InternalSdkError>
+  getCollection<A>(
+    url: string,
+    itemSchema: Schema.ConstraintDecoder<A, never>,
+    params?: QueryParams,
+  ): Effect.Effect<{ items: A[]; totalItems: number; page: number; pageSize: number }, InternalSdkError>
+  post<A>(url: string, body: unknown, schema: Schema.ConstraintDecoder<A, never>): Effect.Effect<A, InternalSdkError>
   postVoid(url: string, body: unknown): Effect.Effect<void, InternalSdkError>
   put(url: string, body: unknown): Effect.Effect<void, InternalSdkError>
   del(url: string): Effect.Effect<void, InternalSdkError>
-  postFormData<A, I>(url: string, formData: FormData, schema: Schema.Schema<A, I>): Effect.Effect<A, InternalSdkError>
+  postFormData<A>(url: string, formData: FormData, schema: Schema.ConstraintDecoder<A, never>): Effect.Effect<A, InternalSdkError>
   postFormDataVoid(url: string, formData: FormData): Effect.Effect<void, InternalSdkError>
 }
 
@@ -54,11 +69,15 @@ export interface Transport {
  * Auth is injected into every request as a Bearer token header.
  * Responses are decoded through the provided Schema.
  * HTTP errors are mapped to InternalSdkError.
+ *
+ * The base URL is intentionally validated inside each returned Effect. This
+ * keeps factories and verb construction lazy while making configuration failure
+ * observable through the typed error channel before fetch is called.
  */
-export function createTransport(baseUrl: string, auth?: AuthOption): Transport {
+export function createTransport(baseUrl: string | undefined, auth?: AuthOption): Transport {
   const buildHeaders = (
     extra?: Record<string, string>,
-  ): Effect.Effect<Record<string, string>> => {
+  ): Effect.Effect<Record<string, string>, Network> => {
     const headers: Record<string, string> = { ...extra }
     if (!auth) return Effect.succeed(headers)
     return pipe(
@@ -70,24 +89,48 @@ export function createTransport(baseUrl: string, auth?: AuthOption): Transport {
     )
   }
 
-  const buildUrl = (path: string, params?: Record<string, string | number | undefined>): string => {
-    const url = new URL(path, baseUrl)
-    if (params) {
-      for (const [key, value] of Object.entries(params)) {
-        if (value !== undefined) url.searchParams.set(key, String(value))
-      }
-    }
-    return url.toString()
-  }
+  const buildUrl = (path: string, params?: QueryParams): Effect.Effect<string, Configuration> =>
+    Effect.try({
+      try: () => {
+        if (baseUrl === undefined || baseUrl.trim() === "") {
+          throw new Error("API URL is not configured")
+        }
+        const parsedBase = new URL(baseUrl)
+        if (parsedBase.protocol !== "http:" && parsedBase.protocol !== "https:") {
+          throw new Error("API URL must use http or https")
+        }
+        const url = new URL(path, parsedBase)
+        if (params) {
+          for (const [key, value] of Object.entries(params)) {
+            if (value !== undefined) url.searchParams.set(key, String(value))
+          }
+        }
+        return url.toString()
+      },
+      catch: (cause) =>
+        new Configuration({
+          message: cause instanceof Error ? cause.message : "Invalid API URL",
+        }),
+    })
 
   const executeFetch = (
     url: string,
     init: RequestInit,
-  ): Effect.Effect<Response, InternalSdkError> =>
+  ): Effect.Effect<Response, Network> =>
     Effect.tryPromise({
-      try: () => fetch(url, init),
-      catch: (cause) => new Network({ message: cause instanceof Error ? cause.message : "Network error", cause }),
+      try: (signal) => fetch(url, { ...init, signal }),
+      catch: (cause) =>
+        new Network({
+          message: cause instanceof Error ? cause.message : "Network error",
+          cause,
+        }),
     })
+
+  const readErrorBody = (response: Response): Effect.Effect<unknown, never> =>
+    Effect.tryPromise({
+      try: () => response.json(),
+      catch: () => null as unknown,
+    }).pipe(Effect.orElseSucceed(() => null as unknown))
 
   const executeJson = (
     url: string,
@@ -110,19 +153,12 @@ export function createTransport(baseUrl: string, auth?: AuthOption): Transport {
       ),
       Effect.flatMap((response) => {
         if (!response.ok) {
-          return pipe(
-            Effect.tryPromise({
-              try: () => response.json(),
-              catch: () => null as unknown,
-            }),
-            Effect.orElseSucceed(() => null as unknown),
-            Effect.flatMap((responseBody) =>
-              Effect.fail(mapStatusToError(response.status, responseBody)),
-            ),
+          return readErrorBody(response).pipe(
+            Effect.flatMap((responseBody) => Effect.fail(mapStatusToError(response.status, responseBody))),
           )
         }
         return Effect.tryPromise({
-          try: () => response.json() as Promise<unknown>,
+          try: () => response.json(),
           catch: () => new Network({ message: "Failed to parse response JSON" }),
         })
       }),
@@ -146,95 +182,101 @@ export function createTransport(baseUrl: string, auth?: AuthOption): Transport {
       ),
       Effect.flatMap((response) => {
         if (!response.ok) {
-          return pipe(
-            Effect.tryPromise({
-              try: () => response.json(),
-              catch: () => null as unknown,
-            }),
-            Effect.orElseSucceed(() => null as unknown),
-            Effect.flatMap((responseBody) =>
-              Effect.fail(mapStatusToError(response.status, responseBody)),
-            ),
+          return readErrorBody(response).pipe(
+            Effect.flatMap((responseBody) => Effect.fail(mapStatusToError(response.status, responseBody))),
           )
         }
         return Effect.void
       }),
     )
 
-  const decodeWith = <A, I>(schema: Schema.Schema<A, I>) =>
-    (json: unknown): Effect.Effect<A, InternalSdkError> =>
-      Schema.decodeUnknown(schema)(json).pipe(
-        Effect.mapError((e) => new Validation({ message: `Decode error: ${e.message}`, fields: {} })),
+  const decodeWith = <A>(schema: Schema.ConstraintDecoder<A, never>) =>
+    (json: unknown): Effect.Effect<A, Validation> =>
+      Schema.decodeUnknownEffect(schema)(json).pipe(
+        Effect.mapError((error) => new Validation({ message: `Decode error: ${error.message}`, fields: {} })),
       )
 
   return {
-    get<A, I>(url: string, schema: Schema.Schema<A, I>, params?: Record<string, string | number | undefined>) {
+    get<A>(url: string, schema: Schema.ConstraintDecoder<A, never>, params?: QueryParams) {
       return pipe(
-        executeJson(buildUrl(url, params), "GET"),
+        buildUrl(url, params),
+        Effect.flatMap((resolvedUrl) => executeJson(resolvedUrl, "GET")),
         Effect.flatMap(decodeWith(schema)),
       )
     },
 
-    getCollection<A, I>(url: string, itemSchema: Schema.Schema<A, I>, params?: Record<string, string | number | undefined>) {
+    getCollection<A>(url: string, itemSchema: Schema.ConstraintDecoder<A, never>, params?: QueryParams) {
       const page = Number(params?.page ?? 1)
       const pageSize = Number(params?.itemsPerPage ?? params?.pageSize ?? 30)
+      const collectionSchema = Schema.Struct({
+        "hydra:member": Schema.Array(itemSchema),
+        "hydra:totalItems": Schema.optional(Schema.Number),
+      })
       return pipe(
-        executeJson(buildUrl(url, params), "GET"),
-        Effect.flatMap((json: unknown) => {
-          const obj = json as Record<string, unknown>
-          const members: unknown[] = (obj?.["hydra:member"] as unknown[]) ?? []
-          const totalItems: number = (obj?.["hydra:totalItems"] as number) ?? 0
-          return pipe(
-            Effect.forEach(members, decodeWith(itemSchema)),
-            Effect.map((items) => ({ items, totalItems, page, pageSize })),
-          )
-        }),
+        buildUrl(url, params),
+        Effect.flatMap((resolvedUrl) => executeJson(resolvedUrl, "GET")),
+        Effect.flatMap(decodeWith(collectionSchema)),
+        Effect.map(({ "hydra:member": items, "hydra:totalItems": totalItems }) => ({
+          items: Array.from(items),
+          totalItems: totalItems ?? 0,
+          page,
+          pageSize,
+        })),
       )
     },
 
-    post<A, I>(url: string, body: unknown, schema: Schema.Schema<A, I>) {
+    post<A>(url: string, body: unknown, schema: Schema.ConstraintDecoder<A, never>) {
       return pipe(
-        executeJson(buildUrl(url), "POST", body),
+        buildUrl(url),
+        Effect.flatMap((resolvedUrl) => executeJson(resolvedUrl, "POST", body)),
         Effect.flatMap(decodeWith(schema)),
       )
     },
 
     postVoid(url: string, body: unknown) {
-      return executeVoid(buildUrl(url), "POST", body)
+      return pipe(
+        buildUrl(url),
+        Effect.flatMap((resolvedUrl) => executeVoid(resolvedUrl, "POST", body)),
+      )
     },
 
     put(url: string, body: unknown) {
-      return executeVoid(buildUrl(url), "PUT", body)
+      return pipe(
+        buildUrl(url),
+        Effect.flatMap((resolvedUrl) => executeVoid(resolvedUrl, "PUT", body)),
+      )
     },
 
     del(url: string) {
-      return executeVoid(buildUrl(url), "DELETE")
+      return pipe(
+        buildUrl(url),
+        Effect.flatMap((resolvedUrl) => executeVoid(resolvedUrl, "DELETE")),
+      )
     },
 
-    postFormData<A, I>(url: string, formData: FormData, schema: Schema.Schema<A, I>) {
+    postFormData<A>(url: string, formData: FormData, schema: Schema.ConstraintDecoder<A, never>) {
       return pipe(
-        buildHeaders({ "Accept": "application/ld+json" }),
-        Effect.flatMap((headers) =>
-          executeFetch(buildUrl(url), {
-            method: "POST",
-            headers,
-            body: formData,
-          }),
+        buildUrl(url),
+        Effect.flatMap((resolvedUrl) =>
+          pipe(
+            buildHeaders({ "Accept": "application/ld+json" }),
+            Effect.flatMap((headers) =>
+              executeFetch(resolvedUrl, {
+                method: "POST",
+                headers,
+                body: formData,
+              }),
+            ),
+          ),
         ),
         Effect.flatMap((response) => {
           if (!response.ok) {
-            return pipe(
-              Effect.tryPromise({
-                try: () => response.json(),
-                catch: () => new Network({ message: "Failed to parse error response" }),
-              }),
-              Effect.flatMap((responseBody) =>
-                Effect.fail(mapStatusToError(response.status, responseBody)),
-              ),
+            return readErrorBody(response).pipe(
+              Effect.flatMap((responseBody) => Effect.fail(mapStatusToError(response.status, responseBody))),
             )
           }
           return Effect.tryPromise({
-            try: () => response.json() as Promise<unknown>,
+            try: () => response.json(),
             catch: () => new Network({ message: "Failed to parse response JSON" }),
           })
         }),
@@ -244,24 +286,23 @@ export function createTransport(baseUrl: string, auth?: AuthOption): Transport {
 
     postFormDataVoid(url: string, formData: FormData) {
       return pipe(
-        buildHeaders(),
-        Effect.flatMap((headers) =>
-          executeFetch(buildUrl(url), {
-            method: "POST",
-            headers,
-            body: formData,
-          }),
+        buildUrl(url),
+        Effect.flatMap((resolvedUrl) =>
+          pipe(
+            buildHeaders(),
+            Effect.flatMap((headers) =>
+              executeFetch(resolvedUrl, {
+                method: "POST",
+                headers,
+                body: formData,
+              }),
+            ),
+          ),
         ),
         Effect.flatMap((response) => {
           if (!response.ok) {
-            return pipe(
-              Effect.tryPromise({
-                try: () => response.json(),
-                catch: () => new Network({ message: "Failed to parse error response" }),
-              }),
-              Effect.flatMap((responseBody) =>
-                Effect.fail(mapStatusToError(response.status, responseBody)),
-              ),
+            return readErrorBody(response).pipe(
+              Effect.flatMap((responseBody) => Effect.fail(mapStatusToError(response.status, responseBody))),
             )
           }
           return Effect.void


### PR DESCRIPTION
## Accepted prerequisite base
This is an explicit stacked integration-base exception, not a one-to-one implementation PR and not a lifecycle advance.

It carries the accepted Effect v4 SDK compatibility payload from spec `0003` and the accepted local Alchemy declaration payload from spec `0005`. Later completed one-to-one PRs consume these shared package, lock, SDK, and preview-declaration edges.

## Review boundary
- `design-specs/0003-effect-v4-receipt-sdk-compatibility.md`
- `design-specs/0005-cloudflare-alchemy-preview.md`
- Exact accepted SDK/preview/Alchemy prerequisite paths and shared lock state

## What is real
The local prerequisite code and declarations are present. Spec 0003 remains consumed/Ready rather than a standalone completed journey, and spec 0005 still lacks provider plan/deploy/reachability/destroy evidence. This PR authorizes no provider, deployment, credential, remote, production, or lifecycle claim.
