### PR TITLE
feat(domain): add the tutor event-envelope tracer

### DIFF
--- a/design-specs/0014-tutor-event-envelope-tracer.md
+++ b/design-specs/0014-tutor-event-envelope-tracer.md
@@ -1,0 +1,347 @@
+# Live design spec 0014 — tutor event-envelope tracer
+
+> **Summary:** One Stage-2 maintainer journey for a pure in-memory `ConductInterview` tracer. It decodes one strict command, folds one `(Person, Cycle)` stream through `ApplicationReceived → InterviewInvited → InterviewAccepted`, accepts `InterviewConducted(scores)` once, returns a typed descriptor-only post-commit effect, rejects malformed and stale input, makes duplicate command handling idempotent, and emits a byte-stable projection/evidence record. It is an accepted design contract, not implementation, persistence, public preview, or operator authority.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| Stable ID | `0014` |
+| Status | `accepted` — product-lead accepted 2026-08-11; implementation accepted/integrated at `a8dafe618907dfd623718802fdaf5712d55f70d4`; no persistence, provider, or external authority |
+| Lifecycle | `Conforming` — 2026-08-11; not `Release-ready` or `Operating` |
+| Base checkpoint | `mono-web` commit `f55fc050efecd03895b08f5417324c414c44dcf4` |
+| Worktree for this spec | `/tmp/mono-web-tutor-event-spec-0014-20260811` |
+| Review | `agent://TutorEventSpecReview0014` — PASS at reviewed spec HEAD `11ef4463` |
+| Intended lane | Stage 2 — tutor event-envelope work |
+| Owner | Tutor event-lane feature lead; product lead remains read-only to production code |
+| Product-lead acceptance | Accepted 2026-08-11 at reviewed spec HEAD `11ef4463`; this grants no implementation, persistence, external-effect, provider, public-preview, or operator authority |
+| Implementation owner/task | `TutorEventImpl0014` |
+| Implementation branch | `impl/0014-tutor-event-envelope-tracer` |
+| Implementation worktree | `/tmp/mono-web-tutor-event-impl-0014-20260811` |
+| Implementation base | Ready state commit `40986855c21243ebcfa1f6470e782e13ed8320ef` |
+| Implementation commit | `a8dafe618907dfd623718802fdaf5712d55f70d4` — accepted/integrated implementation |
+| Code review | `agent://TutorEventCodeReview0014` — PASS at `a8dafe618907dfd623718802fdaf5712d55f70d4` |
+| Runtime verification | `agent://TutorEventRuntimeVerify0014` — PASS at `a8dafe618907dfd623718802fdaf5712d55f70d4` |
+| Integration checkout | `/tmp/mono-web-stage1-conforming-20260810` at `d735e3f8ccd33a684bc8e6f6fbcc95b7f6c78ee9`; clean tracked tree |
+| Journey count | One future maintainer journey; one bounded implementation PR; one blind-first verifier |
+| Evidence destination | Sanitized Evidence section of the future one-to-one PR or approved handoff; no repository evidence file |
+| Authority boundary | No database, migration, Symfony, HTTP, UI, provider, public route, credential, data, or deployment authority |
+
+This accepted spec records implementation integration at `a8dafe618907dfd623718802fdaf5712d55f70d4` and objective code/runtime review. It grants no persistence, provider, external-effect, public-preview, or operator authority; the implementation remains bounded by the capsule below.
+
+## 1. Goal, constraints, and values
+
+### Goal
+
+Give one future domain maintainer a repeatable local journey that:
+
+1. constructs a fixed synthetic `(Person, Cycle)` stream with the canonical initial events;
+2. decodes an unknown `ConductInterview` command through a closed runtime schema;
+3. accepts one lawful `InterviewConducted(scores)` transition and its descriptor-only post-commit effect;
+4. rejects malformed, stale, terminal, out-of-order, and cross-stream input with typed reasons;
+5. returns the same result without a second event or effect for an identical command ID; and
+6. renders one canonical projection and evidence byte sequence with provenance.
+
+This is the smallest tracer that exercises the accepted tutor event-sourcing direction without choosing persistence or an external effect interpreter.
+
+### Constraints
+
+- The stream key is exactly `(Person, Cycle)`. `Cycle` is explicit `Department × Semester`; a department, semester, admission-period, interview, account, or database ID is not a substitute for the tuple.
+- The only event names in this slice are the domain-model names `ApplicationReceived`, `InterviewInvited`, `InterviewAccepted`, and `InterviewConducted(scores)`. Do not invent wire aliases or a second status machine.
+- The transition is pure and immutable. In-memory state may be a returned value containing readonly events and command receipts; it is not a source of record, cache, queue, outbox, `Ref`, service, or persistence adapter.
+- Runtime input is `unknown`. Closed schemas decode it with excess properties rejected. Type assertions, permissive parsing, defaulting a missing score, and silently dropping unknown fields are forbidden.
+- `ConductInterview` must carry complete scores and one answer for every fixed synthetic schema question. Numeric score bounds and the `Suitability` vocabulary must remain the domain-model-derived boundary; the fixture uses the current contract's `0..10` numeric shape and `Ja | Kanskje | Nei` enum only as a bounded input example, not as a new law.
+- `expectedVersion` is mandatory. A command whose expected stream version differs from the current version fails closed as stale and cannot append an event or descriptor.
+- A post-commit effect is a typed immutable descriptor only. The tracer never sends mail/SMS/Slack, performs I/O, invokes a provider, starts a worker, or interprets the descriptor.
+- IDs, times, schema versions, command order, JSON key order, and evidence bytes are fixed. Do not read a clock, random source, environment, network, database, or public preview.
+- The current public preview `p001` is synthetic and separate. This tracer neither calls it nor grants public/provider authority.
+
+### Values
+
+- **Domain language first:** event and law names route to [`docs/domain-model.md`](../../docs/domain-model.md); this file does not redefine that authority.
+- **Fail closed:** invalid representation, stale state, illegal transition, duplicate conflict, and stream mismatch are visible typed failures.
+- **One owner per meaning:** the event fold owns state; the projection owns status; the evidence renderer owns canonical bytes; consumers do not re-derive any of them.
+- **Evidence over implication:** a passing unit scenario proves only its named in-memory case, not a backend, database, deployment, or user journey.
+- **Reversible and disposable:** all state is synthetic, local, and returned in memory; rollback is deleting the implementation PR, not undoing data.
+
+## 2. Authority and current baseline
+
+One link routes each fact; this spec does not copy normative law or process text.
+
+| Concern | Authority and use in this slice |
+|---|---|
+| Program order and lead boundary | [`docs/product-lead-charter.md`](../../docs/product-lead-charter.md) §§1, 4–7, 9, 12. Stage 2 tutor event work waits for the team-to-department evidence lane; the product lead remains read-only. |
+| Lifecycle, capsule, evidence, Drift | [`docs/agentic-development-lifecycle.md`](../../docs/agentic-development-lifecycle.md) §§2, 4–6, 8–12. `Specified` is a complete candidate, not implementation authorization. |
+| Domain meaning | [`docs/domain-model.md`](../../docs/domain-model.md) §§1.1, 1.3–1.4, 2.1–2.2, 7. The tutor chain is event-sourced first; `Cycle`, canonical events, projections, and `T-*`/`S-*`/`R-*` laws remain authoritative there. |
+| Stage-0 topology/effect boundary | [`docs/decisions/0001-cloudflare-topology-and-migration-architecture.md`](../../docs/decisions/0001-cloudflare-topology-and-migration-architecture.md) §§1, 7, 9, 12, 14–15. An event descriptor is not provider authority; persistence and external effects remain context decisions. |
+| Exact Effect capability source | The official local Effect source is `/srv/share/projects/effect`; this is `../effect` relative to the Vektorprogrammet workspace root `/srv/share/projects/vektorprogrammet`, not relative to the `/tmp` implementation worktree. The future writer MUST inspect that source before coding. This spec relies only on the exact signatures for `Schema.Struct`/`Schema.Union`/`Schema.Array`, `Schema.decodeUnknownEffect` (or `decodeUnknownExit`) with `ParseOptions.onExcessProperty = "error"`, and `Effect.gen`/`Effect.succeed`/`Effect.fail`/`Effect.runSyncExit`. No web snippet, v3 translation, unstable persistence module, or copied signature is authority. |
+| Current package baseline | At `f55fc050efecd03895b08f5417324c414c44dcf4`, `packages/domain/package.json` declares `effect` `4.0.0-beta.107`; existing `packages/domain/src/**` is a separate conformance lane and is read-only here. No accepted `packages/domain/src/tutor/**` tracer exists at this checkpoint. |
+
+The writer must re-check the exact beta.107 source at `/srv/share/projects/effect` (`../effect` from the Vektorprogrammet workspace root); that path is not relative to the implementation worktree, and its observed version is not a license to assume signatures across beta releases.
+
+## 3. Canonical tutor contract exercised here
+
+### Stream and events
+
+The write stream is an append-only sequence keyed by:
+
+```text
+(PersonId, Cycle)
+Cycle = { departmentId: DepartmentId, semester: { year: Year, term: Vår | Høst } }
+```
+
+For this tracer, the only accepted sequence is:
+
+```text
+v1 ApplicationReceived
+  → v2 InterviewInvited
+  → v3 InterviewAccepted
+  → v4 InterviewConducted(scores)
+```
+
+The first three events are a fixed fixture, not a command API. The fourth is produced only by `ConductInterview` from the represented `Accepted` state. `status` is a projection over events, never a stored event field.
+
+### Laws and transition boundary
+
+| Canonical law | Observable rule in this tracer | Limit |
+|---|---|---|
+| `T-INT-1` | Conduct only from `Accepted`; the submission has all four score components and one answer per schema question. | Exact score vocabulary/bounds remain derived from the domain boundary; no new law is introduced here. |
+| `S-INT-1` | `InterviewConducted(scores)` structurally carries complete score data, closed `Suitability`, and `conductedAt`. | This fixture does not prove all interview-schema variants. |
+| `T-INT-2` | `Conducted` is terminal; a second conduct is rejected and cannot reopen or overwrite it. | `Cancelled` is not implemented in this tracer. |
+| `R-APP-1` | The projection moves `received → invited → accepted → completed` for this stream. | Placement/assignment is not present, so no `assigned` claim is made. |
+
+`R-APP-2`, `InterviewCancelled`, `Placed`, `Cancelled`, `PeriodExpired`, `PriorEvidenceAttached`, rescheduling, drafts, reminders, response-token expiry, authorization, and all wider tutor rulings are explicit successors. They are not hidden assumptions or implied by this four-event trace.
+
+### Pure transition result
+
+The implementation exposes one pure boundary with equivalent semantics to:
+
+```text
+conductInterview(state, unknownCommand)
+  → Effect<AcceptedResult | DuplicateResult, DecodeError | StaleState | InvalidTransition | DuplicateConflict | StreamMismatch>
+```
+
+The exact TypeScript names are implementation detail; the tagged failure distinctions and observable fields are contract. The function returns a new state/result and never mutates its input.
+
+## 4. Envelope, command, and descriptor contract
+
+### Event envelope
+
+Every event is a closed `EventEnvelopeV1` with these fields:
+
+| Field | Contract |
+|---|---|
+| `schemaVersion` | Literal `1`; envelope schema version, not a domain-law version. |
+| `eventId` | Stable synthetic identity, unique in the trace; no UUID/random generation. |
+| `stream` | `{ personId, cycle: { departmentId, semester: { year, term } } }`; exact `(Person, Cycle)` identity. |
+| `streamVersion` | Positive contiguous integer beginning at `1`; array position and version must agree. It is the sole in-stream order authority. |
+| `eventType` | One of the four canonical names above. |
+| `payload` | Closed event-specific value. Initial events use `{}`; `InterviewConducted` carries `scores` including `conductedAt`. |
+| `occurredAt` | Fixed UTC RFC 3339 value supplied by the fixture; ordering is checked within the stream but no global time order is claimed. |
+| `causationId` | ID of the command/fixture input that caused this event. It is a reference, not executable authority. |
+| `correlationId` | One stable journey ID shared by the fixture trace and its derived evidence. |
+
+An envelope with a different stream, schema version, event name, duplicate ID, missing version, gap, rewind, or non-contiguous order is rejected before projection. Event identity, stream order, causation, correlation, and schema version are distinct fields and must not be collapsed into one ID.
+
+### Conduct command
+
+`ConductInterviewV1` is also closed and contains:
+
+```text
+{
+  schemaVersion: 1,
+  commandId,
+  correlationId,
+  stream: (Person, Cycle),
+  expectedVersion: 3,
+  scores: {
+    explanatoryPower: 0..10,
+    roleModel: 0..10,
+    suitability: 0..10,
+    suitableAssistant: Ja | Kanskje | Nei,
+    answers: { "q-0014-a": string, "q-0014-b": string }
+  }
+}
+```
+
+The two question IDs are synthetic fixture inputs used only to exercise `T-INT-1`'s completeness condition. A future accepted schema may replace them only through an explicit successor/revision; the writer must not silently broaden the answer map.
+
+`commandId` is the idempotency identity. The in-memory receipt ledger stores the canonical command bytes and result for the current run. The same ID with byte-identical command content returns the original accepted result and descriptor without appending anything. The same ID with different content returns `DuplicateCommandConflict` and leaves state unchanged.
+Processing order is part of the contract: decode the closed command first; then look up `commandId` in the ledger; an exact canonical-byte duplicate returns the stored result before stream, version, or transition checks; the same ID with different canonical bytes returns `DuplicateCommandConflict`; only an unseen ID proceeds to stream, stale-version, and transition validation. Thus duplicate idempotency is not masked by the terminal-state rejection.
+
+### Descriptor-only post-commit effect
+
+An accepted transition returns one immutable descriptor, equivalent to:
+
+```text
+{
+  descriptorVersion: 1,
+  kind: "InterviewConductedDescriptor",
+  sourceEventId: "evt-0014-004",
+  causationId: "cmd-0014-conduct",
+  correlationId: "corr-0014-tutor",
+  idempotencyKey: "post-commit:evt-0014-004"
+}
+```
+
+There is no destination, recipient, body, provider, transport, retry, outbox, or effect execution. The descriptor is created only after the event is accepted into the returned in-memory state. A duplicate command returns the prior descriptor as observation, not a second effect request.
+
+## 5. Exact synthetic journey
+
+The future writer starts from the named base, verifies the worktree is clean, and runs one local fixture journey. No step contacts a socket, service, provider, database, or public preview.
+
+### Fixed fixture
+
+Use UTF-8, these exact PII-free values, and no current time:
+
+```text
+fixtureId       = "tutor-event-envelope-0014"
+personId        = "person-synth-0014"
+departmentId    = "department-synth-0014"
+semester        = { year: 2026, term: "Vår" }
+correlationId   = "corr-0014-tutor"
+seed times      = 2026-08-11T09:00:00Z, 09:01:00Z, 09:02:00Z
+conductedAt     = 2026-08-11T09:03:00Z
+seed event IDs  = evt-0014-001, evt-0014-002, evt-0014-003
+command ID      = cmd-0014-conduct
+malformed ID     = cmd-0014-malformed
+stale ID         = cmd-0014-stale
+terminal ID      = cmd-0014-terminal
+conducted ID     = evt-0014-004
+```
+
+The fixture scores are `(8, 9, 7, "Ja")` with answers `{ "q-0014-a": "answer-a", "q-0014-b": "answer-b" }`. These values are synthetic and carry no person, interview, school, account, or contact data.
+
+### Steps and expected observations
+
+| Step | Input/scenario | Required observation |
+|---|---|---|
+| 1 | Build exactly the three closed seed envelopes for the one stream, versions 1–3. | Folded state is `accepted`, projection is `accepted`, and no effect descriptor exists. Any gap, duplicate, or different stream is a typed rejection. |
+| 2 | Decode the exact `ConductInterviewV1` command with `expectedVersion = 3`. | Runtime decoding succeeds only with the closed shape, literal schema version, exact stream, complete scores, and both answers. |
+| 3 | Commit the command. | One v4 `InterviewConducted(scores)` envelope is appended; projection is `completed`; exactly one descriptor is returned; no external call occurs. |
+| 4 | Submit malformed command ID `cmd-0014-malformed` with an extra field or missing answer. | `DecodeError` is observable; event count and descriptor count remain `4` and `1`. |
+| 5 | Submit well-formed command ID `cmd-0014-stale` with `expectedVersion = 2` against the v4 state. | `StaleState` is observable; no event or descriptor is appended. |
+| 6 | Submit distinct well-formed command ID `cmd-0014-terminal` at version 4. | `InvalidTransition` cites `T-INT-2`/terminal `Conducted`; state remains unchanged. |
+| 7 | Submit the exact original command `cmd-0014-conduct` again. | `DuplicateResult` returns byte-identical prior accepted observation before terminal validation; event count remains `4`, descriptor count remains `1`. |
+| 8 | Submit `cmd-0014-conduct` again with one score changed. | `DuplicateCommandConflict` is observable; state and evidence remain unchanged. |
+| 9 | Render the projection/evidence twice from the same resulting state. | Canonical UTF-8 bytes and their SHA-256 digest are identical; provenance points to this spec ID, base commit, fixture ID, schema version, stream, event IDs, and source command ID. |
+
+## 6. Deterministic projection and evidence
+
+The projection is the sole owner of the derived observation:
+
+```text
+{
+  projectionVersion: 1,
+  stream: (Person, Cycle),
+  streamVersion: 4,
+  status: "completed",
+  eventTypes: [
+    "ApplicationReceived",
+    "InterviewInvited",
+    "InterviewAccepted",
+    "InterviewConducted"
+  ],
+  conductedAt: "2026-08-11T09:03:00Z",
+  lawRefs: ["T-INT-1", "S-INT-1", "T-INT-2", "R-APP-1"]
+}
+```
+
+Evidence is a versioned canonical JSON document, encoded as UTF-8 with one trailing newline. Its top-level key order is fixed as `formatVersion`, `specId`, `baseCommit`, `fixtureId`, `schemaVersion`, `correlationId`, `stream`, `cases`, `projection`, `eventIds`, `effectDescriptors`, `provenance`. Object keys are recursively sorted within nested values; arrays retain semantic order. No generated timestamp, random ID, absolute path, environment dump, raw log, PII, or unbounded error text is permitted.
+
+The future evidence record MUST include:
+
+- canonical bytes and `sha256(canonicalBytes)`;
+- base commit `f55fc050efecd03895b08f5417324c414c44dcf4`, spec ID `0014`, fixture ID, and local Effect source/version/hash used by the writer;
+- accepted, rejected, stale, terminal, duplicate, and duplicate-conflict case statuses with typed reason tags;
+- stream/event identity and order, command ID, causation/correlation IDs, schema versions, projection, and descriptor count; and
+- the explicit limits that this proves only a pure in-memory tracer over synthetic input, not persistence, backend parity, authorization, delivery, UI, deployment, provider, public content, or production behavior.
+
+A hash is a reproducibility receipt, not proof of domain conformance. The evidence destination is the future PR/handoff; this spec does not create an evidence artifact.
+
+## 7. Scope, non-goals, dependencies, and conflicts
+
+### Exact future implementation capsule
+
+The future writer may mutate exactly these paths and no others:
+
+- `packages/domain/src/tutor/**` — tutor envelope, command, pure fold/transition, projection, descriptor implementation, and executable tutor fixture/test harness;
+- `packages/domain/package.json` — the `scripts.test` field only, preserving the existing team fixture command and sequencing the tutor fixture command (equivalent to `bun run src/main.ts --fixtures && bun run src/tutor/main.ts --fixtures`); no dependency, version, export, or other manifest key.
+The existing root `test` script remains unchanged (`turbo test`), so package/root test runs both the existing team fixture harness and the tutor fixture harness. The root `bun.lock` remains unchanged. These are capsule restrictions, not mutable paths.
+
+The implementation/tests/fixtures are all under `packages/domain/src/tutor/**`; there is no `src/tutor.test.ts`, separate test directory, new test runner, or new dependency. If the current package convention cannot run both harnesses through this script-only change, stop and request a reviewed capsule revision. Generated coverage, build output, cache, logs, and evidence are disposable and never committed.
+
+
+### Non-goals
+
+This slice does not include:
+
+- any database, event store, migration, schema migration, ORM, repository, durable outbox, queue, workflow, retry, or persistence decision;
+- Symfony, API/HTTP/RPC, SDK, homepage, dashboard, browser/UI, auth/authz, PII, public content, Worker, Hyperdrive, D1, R2, KV, Cloudflare, Alchemy, Wrangler, provider, route, deployment, DNS, credentials, or public preview work;
+- execution or interpretation of the descriptor, email/SMS/Slack delivery, telemetry, or external effects;
+- placement, school allocation, `AssistantHistory`, certificate, cancellation, expiration, prior-cycle evidence, reminder, reschedule, draft, response-token, or full `R-APP-2` outcome behavior;
+- changing the domain model, adding a new law, claiming all tutor events or all contexts are event-sourced, or replacing the current Symfony/MySQL parity line; or
+- changing `packages/domain/package.json` beyond the `scripts.test` field, changing any lockfile, root configuration, current S-DEP-2 code, public `p001`, or another live spec.
+
+### Dependencies and conflicts
+
+- **Predecessor:** accepted [`0004-team-department-conformance-evidence.md`](./0004-team-department-conformance-evidence.md) is `Conforming`; its implementation capsule is **CLOSED/CONSUMED** at `bc7f459`, `897228e`, and `c90ec2d`, with independent review/runtime evidence at `c90ec2d`. This spec does not redispatch or edit 0004. The team-to-department evidence lane must exit before Stage 2 tutor event-envelope work.
+- **Required authorities:** Stage-0 ADR 0001, the charter, lifecycle, domain model, and the closed/consumed 0004 disposition must remain resolvable at implementation start. A conflict enters `Drift`; it is not repaired by weakening this tracer.
+- **Effect boundary:** the writer verifies only the exact local `/srv/share/projects/effect` (`../effect` from the Vektorprogrammet workspace root) source signatures used by this capsule. No dependency refresh or lock edge is authorized; the existing beta.107 package edge remains read-only.
+- **Resource conflict:** `packages/domain/src/tutor/**` is disjoint from the consumed 0004 implementation/evidence ownership. No other writer may mutate this tutor path concurrently. Existing 0004 source/evidence and other domain source files remain outside this capsule; there is no root lock edge.
+- **Separate lanes:** public synthetic preview `p001`, security, public content, SDK, persistence, and later tutor successors have independent specs and authority. They are not dependencies hidden by this tracer.
+
+## 8. Falsifiers and definition of done
+
+The implementation enters `Drift` if any condition succeeds when it should fail:
+
+- an unknown field, missing field, wrong literal schema version, malformed score, wrong answer cardinality, or invalid stream decodes successfully;
+- conduct from `Invited`, a stale expected version, a stream mismatch, an event gap/duplicate, or terminal `Conducted` appends an event;
+- duplicate command content appends a second event or descriptor, or duplicate command ID with changed content is treated as success;
+- a descriptor has a destination or is interpreted by a transport/provider; the tracer performs I/O or reads ambient time/randomness;
+- projection/status is stored as an event or re-derived by a second owner;
+- two identical runs produce different canonical evidence bytes/digests or omit provenance/limits; or
+- a review, log, preview URL, package install, or deployment is presented as persistence, backend, domain-conformance, public, or production proof.
+
+Done for the future implementation means: the exact tutor source/test/fixture capsule is the only changed implementation path; the sole manifest exception is `packages/domain/package.json` `scripts.test`, with no dependency or lock change; local Effect signatures are source-verified; the existing package/root test path runs both the team fixture harness and tutor fixture harness; the tutor harness observes every Step 1–9 outcome; typed failures preserve state; descriptor count is idempotent; projection and evidence bytes/digest are repeatable; sanitized provenance and limitations are retained; temporary outputs are removed; the worktree is clean; and no linked Drift remains. This candidate itself is not done-as-implementation and has no runtime evidence.
+
+## 9. Rollout, rollback, and lifecycle gates
+
+There is no rollout. The future PR is an in-memory library/test change with no route, release, provider, database, data, credential, or public effect. It may not be presented as a tutor backend or preview.
+
+Rollback is a local revert or disposal of the one-to-one implementation PR/worktree. Since no durable state or external effect exists, no migration rollback, data restore, route switch, or provider destroy is needed. If a future successor adds persistence or an effect interpreter, it requires a new context decision, live spec, evidence, and operator-owned rollback; it cannot extend this capsule silently.
+
+Lifecycle intent:
+
+- **Specified:** this complete intent, authority routing, one journey, capsule, evidence contract, falsifiers, and limits are present.
+- **Ready:** product-lead acceptance, predecessor confirmation, independent review, and the exact implementation task/worktree/base were recorded; this gate is superseded by the current `Conforming` state.
+- **Building:** one writer in the named worktree changes only the allowed paths and records objective local evidence.
+- **Experienceable/Conforming (current):** implementation accepted/integrated at `a8dafe618907dfd623718802fdaf5712d55f70d4`; code review `agent://TutorEventCodeReview0014` and runtime verification `agent://TutorEventRuntimeVerify0014` are PASS; no persistence, provider, external, public-preview, or operator authority is granted.
+- **Release-ready/Operating:** not applicable to this pure tracer; any external or public action requires a later accepted spec and scoped operator authority.
+
+## 10. Task capsule and Drift path
+
+| Field | Capsule content |
+|---|---|
+| Spec ID/path | `0014`; `mono-web/design-specs/0014-tutor-event-envelope-tracer.md` |
+| Role/objective | One future tutor-domain writer; realize the pure in-memory `ConductInterview` tracer and the exact Step 1–9 observations. |
+| Base/worktree | Start at `f55fc050efecd03895b08f5417324c414c44dcf4` in a fresh isolated worktree; this spec's authoring worktree is `/tmp/mono-web-tutor-event-spec-0014-20260811`. Record the implementation worktree and clean checkpoint before mutation. |
+| Allowed mutations | Exactly `packages/domain/src/tutor/**` plus `packages/domain/package.json` `scripts.test` only. The root `test` script and root `bun.lock` remain unchanged; implementation/tests/fixtures are executable under `src/tutor/**`; no test runner or dependency is added. |
+| Forbidden mutations/effects | Every other source/config/manifest/lock/provider/data/UI/server path; any package manifest key other than `scripts.test`; persistence; migration; network; provider/public preview; credentials/PII; descriptor execution; edits to this spec or domain authority. |
+| Dependencies/conflicts | Closed/consumed 0004 capsule at `bc7f459`/`897228e`/`c90ec2d`; team-to-department evidence exit; accepted Stage-0 ADR and domain/lifecycle/charter authorities; `/srv/share/projects/effect` (`../effect` from workspace root) source verification; exclusive disjoint ownership of `src/tutor/**`; no lock edge. |
+| Context/law/interface refs | Domain model §§1.1, 1.3–1.4, 2.1–2.2 (`T-INT-1`, `S-INT-1`, `T-INT-2`, `R-APP-1`); charter §5; lifecycle §§4–6, 9, 12; ADR §§7, 9, 12, 14–15; accepted 0004 closure; exact local `/srv/share/projects/effect` source files selected by the writer. |
+| Sensitive-data policy | Fixed synthetic technical IDs/times only; no names, emails, tokens, credentials, production rows, public URLs, or raw logs. Keep command/event payloads in memory and sanitize evidence. |
+| Verification scenarios | Closed-schema malformed input; canonical seed fold; accepted conduct; stale version; terminal transition; duplicate and duplicate-conflict; envelope identity/order/causation/correlation/schema checks; descriptor non-execution; two-run canonical evidence byte/digest comparison; path review. |
+| Exit criteria | Step 1–9 evidence recorded; the existing package/root test path runs both the team fixture harness and tutor fixture harness; package type check passes for the changed boundary; exact path/manifest capsule honored; root lock unchanged; clean worktree; no unresolved linked Drift; sanitized handoff ready for blind-first review. |
+| Evidence destination | Sanitized Evidence section of the one-to-one PR or approved handoff; no committed evidence file. |
+| Drift path | Stop on a falsifier, source/API mismatch, authority disagreement, unresolved score/schema ruling, path need, or unexpected effect. Notify product lead and owning authority; link the observation and return to `Specified` for intent change or `Building` for implementation correction. |
+| Cleanup | Remove generated test/coverage/cache/log files and temporary fixtures; retain only sanitized deterministic evidence; confirm no external process, socket, credential, or untracked file remains. |
+| Operator authorization | None required or permitted. Any external effect is out of capsule and requires a separate lifecycle-scoped operator record. |
+
+### Successors, not assumptions
+
+A later spec must explicitly decide how this in-memory trace connects to a durable event log, command authorization, event replay/import, complete tutor outcomes, event retention/versioning, schema evolution, external delivery, public APIs, persistence, and rollback. None is implied by the envelope shape or the descriptor in this slice.
+
+### Drift log for this candidate
+
+Implementation and runtime observations are recorded by the cited PASS reviews at integrated commit `a8dafe618907dfd623718802fdaf5712d55f70d4`. Initial disposition is **open/empty** for any new disagreement: record owner, artifact, claim, and lifecycle return path rather than editing it away.

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "report": "bun run src/main.ts",
-    "test": "bun run src/main.ts --fixtures",
+    "test": "bun run src/main.ts --fixtures && bun run src/tutor/main.ts --fixtures",
     "check-types": "tsc --noEmit",
     "build": "tsc --noEmit",
     "lint": "oxlint"

--- a/packages/domain/src/tutor/evidence.ts
+++ b/packages/domain/src/tutor/evidence.ts
@@ -1,0 +1,79 @@
+import { createHash } from "node:crypto";
+import type { Evidence } from "./schema.js";
+
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | ReadonlyArray<JsonValue>
+  | { readonly [key: string]: JsonValue };
+
+const sortedJsonValue = (input: unknown): JsonValue => {
+  if (input === null) return null;
+  if (typeof input === "string" || typeof input === "boolean" || typeof input === "number") return input;
+  if (Array.isArray(input)) return input.map((value) => sortedJsonValue(value));
+  if (typeof input === "object") {
+    const output: Record<string, JsonValue> = {};
+    for (const [key, value] of Object.entries(input).sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))) {
+      output[key] = sortedJsonValue(value);
+    }
+    return output;
+  }
+  throw new Error("canonical JSON cannot contain undefined or executable values");
+};
+
+const encodeJsonValue = (value: JsonValue): string => {
+  const encoded = JSON.stringify(value);
+  if (encoded === undefined) throw new Error("canonical JSON encoding failed");
+  return encoded;
+};
+
+export const canonicalJson = (value: unknown): string => encodeJsonValue(sortedJsonValue(value));
+
+export const canonicalJsonBytes = (value: unknown): Uint8Array =>
+  new TextEncoder().encode(canonicalJson(value));
+
+export const sha256Hex = (bytes: Uint8Array): string => createHash("sha256").update(bytes).digest("hex");
+
+export const canonicalEvidenceJson = (evidence: Evidence): string => {
+  const orderedEntries: ReadonlyArray<readonly [string, unknown]> = [
+    ["formatVersion", evidence.formatVersion],
+    ["specId", evidence.specId],
+    ["baseCommit", evidence.baseCommit],
+    ["fixtureId", evidence.fixtureId],
+    ["schemaVersion", evidence.schemaVersion],
+    ["correlationId", evidence.correlationId],
+    ["stream", evidence.stream],
+    ["cases", evidence.cases],
+    ["projection", evidence.projection],
+    ["eventIds", evidence.eventIds],
+    ["effectDescriptors", evidence.effectDescriptors],
+    ["provenance", evidence.provenance],
+  ];
+  const encodedEntries = orderedEntries.map(
+    ([key, value]) => `${JSON.stringify(key)}:${canonicalJson(value)}`,
+  );
+  return `{${encodedEntries.join(",")}}`;
+};
+
+export const canonicalEvidenceBytes = (evidence: Evidence): Uint8Array =>
+  new TextEncoder().encode(`${canonicalEvidenceJson(evidence)}\n`);
+
+export interface EvidenceArtifact {
+  readonly document: Evidence;
+  readonly canonicalJson: string;
+  readonly bytes: Uint8Array;
+  readonly digest: string;
+}
+
+export const renderEvidence = (document: Evidence): EvidenceArtifact => {
+  const canonical = canonicalEvidenceJson(document);
+  const bytes = new TextEncoder().encode(`${canonical}\n`);
+  return {
+    document,
+    canonicalJson: canonical,
+    bytes,
+    digest: sha256Hex(bytes),
+  };
+};

--- a/packages/domain/src/tutor/fixture.ts
+++ b/packages/domain/src/tutor/fixture.ts
@@ -1,0 +1,401 @@
+import { Cause, Effect, Exit, Result } from "effect";
+import type {
+  ConductInterviewV1,
+  CounterexampleReceipt,
+  Evidence,
+  EvidenceCase,
+  EventEnvelopeV1,
+  StreamKey,
+  ReasonCode,
+} from "./schema.js";
+import { decodeConductInterviewV1, decodeEvidence } from "./schema.js";
+import {
+  canonicalEvidenceBytes,
+  canonicalEvidenceJson,
+  renderEvidence,
+  type EvidenceArtifact,
+} from "./evidence.js";
+import {
+  conductInterview,
+  createTutorState,
+  foldEvents,
+  projectFoldedState,
+  type ConductInterviewResult,
+  type TutorFailure,
+  type TutorState,
+} from "./tracer.js";
+
+export const FIXTURE_ID = "tutor-event-envelope-0014";
+export const FIXTURE_PERSON_ID = "person-synth-0014";
+export const FIXTURE_DEPARTMENT_ID = "department-synth-0014";
+export const FIXTURE_CORRELATION_ID = "corr-0014-tutor";
+export const FIXTURE_COMMAND_ID = "cmd-0014-conduct";
+export const MALFORMED_COMMAND_ID = "cmd-0014-malformed";
+export const STALE_COMMAND_ID = "cmd-0014-stale";
+export const TERMINAL_COMMAND_ID = "cmd-0014-terminal";
+export const CONDUCTED_EVENT_ID = "evt-0014-004";
+export const EFFECT_SOURCE_HASH = "2e1ddbebd9dd5cf0738ea08b2e832a7c39ae990f";
+export const BASE_COMMIT = "f55fc050efecd03895b08f5417324c414c44dcf4";
+
+const FIXTURE_STREAM: StreamKey = {
+  personId: FIXTURE_PERSON_ID,
+  cycle: {
+    departmentId: FIXTURE_DEPARTMENT_ID,
+    semester: { year: 2026, term: "Vår" },
+  },
+};
+
+const SEED_EVENT_1 = {
+  schemaVersion: 1,
+  eventId: "evt-0014-001",
+  stream: FIXTURE_STREAM,
+  streamVersion: 1,
+  eventType: "ApplicationReceived",
+  payload: {},
+  occurredAt: "2026-08-11T09:00:00Z",
+  causationId: FIXTURE_ID,
+  correlationId: FIXTURE_CORRELATION_ID,
+} satisfies EventEnvelopeV1;
+
+const SEED_EVENT_2 = {
+  schemaVersion: 1,
+  eventId: "evt-0014-002",
+  stream: FIXTURE_STREAM,
+  streamVersion: 2,
+  eventType: "InterviewInvited",
+  payload: {},
+  occurredAt: "2026-08-11T09:01:00Z",
+  causationId: FIXTURE_ID,
+  correlationId: FIXTURE_CORRELATION_ID,
+} satisfies EventEnvelopeV1;
+
+const SEED_EVENT_3 = {
+  schemaVersion: 1,
+  eventId: "evt-0014-003",
+  stream: FIXTURE_STREAM,
+  streamVersion: 3,
+  eventType: "InterviewAccepted",
+  payload: {},
+  occurredAt: "2026-08-11T09:02:00Z",
+  causationId: FIXTURE_ID,
+  correlationId: FIXTURE_CORRELATION_ID,
+} satisfies EventEnvelopeV1;
+
+export const FIXTURE_SEED_EVENTS: ReadonlyArray<EventEnvelopeV1> = [SEED_EVENT_1, SEED_EVENT_2, SEED_EVENT_3];
+
+export const FIXTURE_COMMAND: ConductInterviewV1 = {
+  schemaVersion: 1,
+  commandId: FIXTURE_COMMAND_ID,
+  correlationId: FIXTURE_CORRELATION_ID,
+  stream: FIXTURE_STREAM,
+  expectedVersion: 3,
+  scores: {
+    explanatoryPower: 8,
+    roleModel: 9,
+    suitability: 7,
+    suitableAssistant: "Ja",
+    answers: {
+      "q-0014-a": "answer-a",
+      "q-0014-b": "answer-b",
+    },
+  },
+};
+
+const OTHER_STREAM: StreamKey = {
+  ...FIXTURE_STREAM,
+  personId: "person-synth-0014-other",
+};
+
+const runSync = <A, E>(effect: Effect.Effect<A, E>): A => {
+  const exit = Effect.runSyncExit(effect);
+  if (Exit.isSuccess(exit)) return exit.value;
+  throw new Error("fixture expected effect success");
+};
+
+const runFailure = <A, E>(effect: Effect.Effect<A, E>): E => {
+  const exit = Effect.runSyncExit(effect);
+  if (Exit.isSuccess(exit)) throw new Error("fixture expected effect failure");
+  const failure = Cause.findError(exit.cause);
+  if (Result.isSuccess(failure)) return failure.success;
+  throw new Error("fixture effect failed without a typed error");
+};
+
+const assert = (condition: boolean, message: string): void => {
+  if (!condition) throw new Error(message);
+};
+
+const descriptorCount = (state: TutorState): number => state.receipts.length;
+
+const caseObservation = (
+  caseId: string,
+  status: EvidenceCase["status"],
+  reasonCode: ReasonCode,
+  commandId: string,
+  state: TutorState,
+): EvidenceCase => ({
+  caseId,
+  status,
+  reasonCode,
+  commandId,
+  streamVersion: state.events.length,
+  eventCount: state.events.length,
+  descriptorCount: descriptorCount(state),
+});
+
+const preservedCounterexample = (
+  caseId: string,
+  expectedTag: TutorFailure["_tag"],
+  expectedReasonCode: ReasonCode,
+  failure: TutorFailure,
+  state: TutorState,
+): CounterexampleReceipt => {
+  assert(failure._tag === expectedTag, `${caseId} tag mismatch`);
+  assert(failure.reasonCode === expectedReasonCode, `${caseId} reason mismatch`);
+  return {
+    caseId,
+    expectedReasonCode,
+    observedReasonCode: failure.reasonCode,
+    preservedEventCount: state.events.length,
+    preservedDescriptorCount: descriptorCount(state),
+  };
+};
+
+const statusCounts = (cases: ReadonlyArray<EvidenceCase>): Readonly<Record<string, number>> => {
+  const counts: Record<string, number> = {};
+  for (const observation of cases) {
+    const previous = counts[observation.status];
+    counts[observation.status] = previous === undefined ? 1 : previous + 1;
+  }
+  return counts;
+};
+
+const reasonCounts = (cases: ReadonlyArray<EvidenceCase>): Readonly<Record<string, number>> => {
+  const counts: Record<string, number> = {};
+  for (const observation of cases) {
+    const previous = counts[observation.reasonCode];
+    counts[observation.reasonCode] = previous === undefined ? 1 : previous + 1;
+  }
+  return counts;
+};
+
+export interface TutorFixtureRun {
+  readonly passed: true;
+  readonly scenarioCount: number;
+  readonly statusCounts: Readonly<Record<string, number>>;
+  readonly reasonCounts: Readonly<Record<string, number>>;
+  readonly eventCount: 4;
+  readonly descriptorCount: 1;
+  readonly counterexampleReceipts: ReadonlyArray<CounterexampleReceipt>;
+  readonly evidence: EvidenceArtifact;
+}
+
+export const runTutorFixture = (): TutorFixtureRun => {
+  const seedState = runSync(createTutorState(FIXTURE_SEED_EVENTS));
+  const seedFolded = runSync(foldEvents(seedState.events));
+  const seedProjection = projectFoldedState(seedFolded);
+  assert(seedProjection.status === "accepted", "seed projection must be accepted");
+  assert(seedState.events.length === 3, "seed event count must be three");
+  assert(descriptorCount(seedState) === 0, "seed descriptor count must be zero");
+
+  const decodedCommand = runSync(decodeConductInterviewV1(FIXTURE_COMMAND));
+  assert(decodedCommand.commandId === FIXTURE_COMMAND_ID, "fixture command decode failed");
+
+  const accepted = runSync(conductInterview(seedState, FIXTURE_COMMAND));
+  assert(accepted._tag === "AcceptedResult", "conduct command must be accepted");
+  const acceptedState = accepted.state;
+  assert(acceptedState.events.length === 4, "accepted event count must be four");
+  assert(descriptorCount(acceptedState) === 1, "accepted descriptor count must be one");
+  assert(accepted.observation.projection.status === "completed", "accepted projection must be completed");
+  assert(accepted.observation.eventId === CONDUCTED_EVENT_ID, "conducted event identity must be fixed");
+  assert(accepted.observation.descriptor.idempotencyKey === "post-commit:evt-0014-004", "descriptor key mismatch");
+
+  const malformedCommand: unknown = {
+    ...FIXTURE_COMMAND,
+    commandId: MALFORMED_COMMAND_ID,
+    extraField: "reject",
+  };
+  const malformedFailure = runFailure(conductInterview(acceptedState, malformedCommand));
+  assert(malformedFailure._tag === "DecodeError", "malformed command must be a decode error");
+  assert(acceptedState.events.length === 4 && descriptorCount(acceptedState) === 1, "malformed changed state");
+
+  const staleCommand: unknown = {
+    ...FIXTURE_COMMAND,
+    commandId: STALE_COMMAND_ID,
+    expectedVersion: 2,
+  };
+  const staleFailure = runFailure(conductInterview(acceptedState, staleCommand));
+  assert(staleFailure._tag === "StaleState", "stale command must be stale");
+
+  const terminalCommand: unknown = {
+    ...FIXTURE_COMMAND,
+    commandId: TERMINAL_COMMAND_ID,
+    expectedVersion: 4,
+  };
+  const terminalFailure = runFailure(conductInterview(acceptedState, terminalCommand));
+  assert(terminalFailure._tag === "InvalidTransition", "terminal command must be an invalid transition");
+  assert(terminalFailure.reasonCode === "TERMINAL_CONDUCTED", "terminal law reason mismatch");
+
+  const duplicate = runSync(conductInterview(acceptedState, FIXTURE_COMMAND));
+  assert(duplicate._tag === "DuplicateResult", "identical command must be duplicate");
+  assert(duplicate.state === acceptedState, "duplicate must preserve state identity");
+  assert(duplicate.observationBytes === accepted.observationBytes, "duplicate observation bytes changed");
+  assert(acceptedState.events.length === 4 && descriptorCount(acceptedState) === 1, "duplicate appended state");
+
+  const duplicateConflictCommand: unknown = {
+    ...FIXTURE_COMMAND,
+    scores: { ...FIXTURE_COMMAND.scores, explanatoryPower: 7 },
+  };
+  const duplicateConflictFailure = runFailure(conductInterview(acceptedState, duplicateConflictCommand));
+  assert(
+    duplicateConflictFailure._tag === "DuplicateCommandConflict",
+    "changed duplicate command must conflict",
+  );
+  assert(acceptedState.events.length === 4 && descriptorCount(acceptedState) === 1, "duplicate conflict changed state");
+
+  const cases: ReadonlyArray<EvidenceCase> = [
+    caseObservation("step-01-seed", "accepted", "SEED_ACCEPTED", FIXTURE_ID, seedState),
+    caseObservation("step-02-command-decode", "accepted", "COMMAND_DECODED", FIXTURE_COMMAND_ID, seedState),
+    caseObservation("step-03-conduct", "accepted", "INTERVIEW_CONDUCTED", FIXTURE_COMMAND_ID, acceptedState),
+    caseObservation("step-04-malformed", "rejected", malformedFailure.reasonCode, MALFORMED_COMMAND_ID, acceptedState),
+    caseObservation("step-05-stale", "stale", staleFailure.reasonCode, STALE_COMMAND_ID, acceptedState),
+    caseObservation("step-06-terminal", "terminal", terminalFailure.reasonCode, TERMINAL_COMMAND_ID, acceptedState),
+    caseObservation("step-07-duplicate", "duplicate", "DUPLICATE_IDEMPOTENT", FIXTURE_COMMAND_ID, acceptedState),
+    caseObservation(
+      "step-08-duplicate-conflict",
+      "duplicate-conflict",
+      duplicateConflictFailure.reasonCode,
+      FIXTURE_COMMAND_ID,
+      acceptedState,
+    ),
+    caseObservation("step-09-evidence", "accepted", "EVIDENCE_REPEATABLE", FIXTURE_COMMAND_ID, acceptedState),
+  ];
+  const scenarioCount = cases.length;
+  assert(scenarioCount === 9, "fixture must contain exactly nine journey cases");
+
+  const crossStreamCommand: unknown = { ...FIXTURE_COMMAND, commandId: "cmd-0014-cross-stream", stream: OTHER_STREAM };
+  const crossStreamFailure = runFailure(conductInterview(acceptedState, crossStreamCommand));
+  const emptyStreamFailure = runFailure(foldEvents([]));
+  const gapFailure = runFailure(
+    foldEvents([SEED_EVENT_1, { ...SEED_EVENT_2, streamVersion: 3 }, SEED_EVENT_3]),
+  );
+  const canonicalSequenceFailure = runFailure(
+    foldEvents([SEED_EVENT_1, { ...SEED_EVENT_2, eventType: "InterviewAccepted" }, SEED_EVENT_3]),
+  );
+  const occurredAtRewindFailure = runFailure(
+    foldEvents([SEED_EVENT_1, { ...SEED_EVENT_2, occurredAt: "2026-08-11T08:59:00Z" }, SEED_EVENT_3]),
+  );
+  const duplicateEventFailure = runFailure(
+    foldEvents([SEED_EVENT_1, { ...SEED_EVENT_2, eventId: SEED_EVENT_1.eventId }, SEED_EVENT_3]),
+  );
+  const eventStreamFailure = runFailure(
+    foldEvents([SEED_EVENT_1, { ...SEED_EVENT_2, stream: OTHER_STREAM }, SEED_EVENT_3]),
+  );
+  const eventCorrelationFailure = runFailure(
+    foldEvents([SEED_EVENT_1, { ...SEED_EVENT_2, correlationId: "corr-0014-other" }, SEED_EVENT_3]),
+  );
+  const schemaVersionFailure = runFailure(foldEvents([{ ...SEED_EVENT_1, schemaVersion: 2 }]));
+  const invitedState = runSync(createTutorState([SEED_EVENT_1, SEED_EVENT_2]));
+  const invitedCommand: unknown = { ...FIXTURE_COMMAND, commandId: "cmd-0014-invited", expectedVersion: 2 };
+  const invitedFailure = runFailure(conductInterview(invitedState, invitedCommand));
+  const incompleteAnswerFailure = runFailure(
+    conductInterview(acceptedState, {
+      ...FIXTURE_COMMAND,
+      commandId: "cmd-0014-incomplete-answer",
+      scores: { ...FIXTURE_COMMAND.scores, answers: { "q-0014-a": "answer-a" } },
+    }),
+  );
+  const invalidScoreFailure = runFailure(
+    conductInterview(acceptedState, {
+      ...FIXTURE_COMMAND,
+      commandId: "cmd-0014-invalid-score",
+      scores: { ...FIXTURE_COMMAND.scores, explanatoryPower: 11 },
+    }),
+  );
+
+  const counterexampleReceipts: ReadonlyArray<CounterexampleReceipt> = [
+    preservedCounterexample("counterexample-cross-stream", "StreamMismatch", "STREAM_MISMATCH", crossStreamFailure, acceptedState),
+    preservedCounterexample("counterexample-empty-stream", "InvalidTransition", "EMPTY_STREAM", emptyStreamFailure, seedState),
+    preservedCounterexample("counterexample-gap", "OutOfOrderEvent", "STREAM_VERSION_GAP", gapFailure, seedState),
+    preservedCounterexample("counterexample-canonical-sequence", "InvalidTransition", "CANONICAL_SEQUENCE", canonicalSequenceFailure, seedState),
+    preservedCounterexample("counterexample-occurred-at-rewind", "OutOfOrderEvent", "OCCURRED_AT_REWIND", occurredAtRewindFailure, seedState),
+    preservedCounterexample("counterexample-duplicate-event", "DuplicateEvent", "DUPLICATE_EVENT_ID", duplicateEventFailure, seedState),
+    preservedCounterexample("counterexample-event-stream", "StreamMismatch", "STREAM_MISMATCH", eventStreamFailure, seedState),
+    preservedCounterexample("counterexample-event-correlation", "StreamMismatch", "STREAM_MISMATCH", eventCorrelationFailure, seedState),
+    preservedCounterexample("counterexample-schema-version", "DecodeError", "DECODE_ERROR", schemaVersionFailure, seedState),
+    preservedCounterexample("counterexample-invited", "InvalidTransition", "CONDUCT_REQUIRES_ACCEPTED", invitedFailure, invitedState),
+    preservedCounterexample("counterexample-answer-cardinality", "DecodeError", "DECODE_ERROR", incompleteAnswerFailure, acceptedState),
+    preservedCounterexample("counterexample-score-bound", "DecodeError", "DECODE_ERROR", invalidScoreFailure, acceptedState),
+  ];
+
+
+  const finalFolded = runSync(foldEvents(acceptedState.events));
+  const finalProjection = projectFoldedState(finalFolded);
+  const finalDescriptor = accepted.observation.descriptor;
+  const evidenceDocument: Evidence = {
+    formatVersion: 1,
+    specId: "0014",
+    baseCommit: BASE_COMMIT,
+    fixtureId: FIXTURE_ID,
+    schemaVersion: 1,
+    correlationId: FIXTURE_CORRELATION_ID,
+    stream: FIXTURE_STREAM,
+    cases,
+    projection: finalProjection,
+    eventIds: acceptedState.events.map((event) => event.eventId),
+    effectDescriptors: [finalDescriptor],
+    provenance: {
+      effectSource: "local-effect-source",
+      effectVersion: "4.0.0-beta.107",
+      effectSourceHash: EFFECT_SOURCE_HASH,
+      sourceCommandId: FIXTURE_COMMAND_ID,
+      eventIds: acceptedState.events.map((event) => event.eventId),
+      limits: [
+        "pure-in-memory-tracer",
+        "synthetic-input-only",
+        "no-persistence-proof",
+        "no-backend-parity-proof",
+        "no-authorization-proof",
+        "no-delivery-proof",
+        "no-ui-proof",
+        "no-deployment-proof",
+        "no-provider-proof",
+        "no-public-content-proof",
+        "no-production-proof",
+      ],
+      counterexampleReceipts,
+    },
+  };
+
+  runSync(decodeEvidence(evidenceDocument));
+  const firstArtifact = renderEvidence(evidenceDocument);
+  const secondArtifact = renderEvidence(evidenceDocument);
+  const independentlyEncodedJson = canonicalEvidenceJson(evidenceDocument);
+  const independentlyEncodedBytes = canonicalEvidenceBytes(evidenceDocument);
+  assert(firstArtifact.canonicalJson === secondArtifact.canonicalJson, "evidence canonical JSON changed");
+  assert(firstArtifact.canonicalJson === independentlyEncodedJson, "evidence JSON renderer disagrees");
+  assert(firstArtifact.digest === secondArtifact.digest, "evidence digest changed");
+  assert(firstArtifact.bytes.length === secondArtifact.bytes.length, "evidence byte length changed");
+  assert(
+    firstArtifact.bytes.every((byte, index) => byte === secondArtifact.bytes[index]),
+    "evidence bytes changed",
+  );
+  assert(firstArtifact.bytes.length === independentlyEncodedBytes.length, "evidence bytes renderer disagrees");
+  assert(
+    firstArtifact.bytes.every((byte, index) => byte === independentlyEncodedBytes[index]),
+    "evidence bytes renderer disagrees",
+  );
+  assert(firstArtifact.canonicalJson.endsWith("}") && firstArtifact.bytes.at(-1) === 10, "evidence newline missing");
+
+  return {
+    passed: true,
+    scenarioCount,
+    statusCounts: statusCounts(cases),
+    reasonCounts: reasonCounts(cases),
+    eventCount: 4,
+    descriptorCount: 1,
+    counterexampleReceipts,
+    evidence: firstArtifact,
+  };
+};
+
+export type FixtureTransitionResult = ConductInterviewResult;

--- a/packages/domain/src/tutor/index.ts
+++ b/packages/domain/src/tutor/index.ts
@@ -1,0 +1,4 @@
+export * from "./schema.js";
+export * from "./evidence.js";
+export * from "./tracer.js";
+export * from "./fixture.js";

--- a/packages/domain/src/tutor/main.ts
+++ b/packages/domain/src/tutor/main.ts
@@ -1,0 +1,32 @@
+import { canonicalJson } from "./evidence.js";
+import { FIXTURE_ID, runTutorFixture } from "./fixture.js";
+
+export const main = (args: ReadonlyArray<string> = process.argv.slice(2)): number => {
+  if (args.length !== 1 || args[0] !== "--fixtures") {
+    process.stderr.write("usage: bun run src/tutor/main.ts --fixtures\n");
+    return 1;
+  }
+
+  try {
+    const run = runTutorFixture();
+    const summary = {
+      fixtureId: FIXTURE_ID,
+      scenarioCount: run.scenarioCount,
+      statusCounts: run.statusCounts,
+      reasonCounts: run.reasonCounts,
+      eventCount: run.eventCount,
+      descriptorCount: run.descriptorCount,
+      evidenceDigest: run.evidence.digest,
+      evidenceByteLength: run.evidence.bytes.length,
+      counterexampleReceipts: run.counterexampleReceipts,
+    };
+    process.stdout.write(`${canonicalJson(summary)}\n${run.evidence.canonicalJson}\n`);
+    return 0;
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "tutor fixture failed";
+    process.stderr.write(`${canonicalJson({ fixtureId: FIXTURE_ID, error: message })}\n`);
+    return 1;
+  }
+};
+
+if (import.meta.main) process.exitCode = main();

--- a/packages/domain/src/tutor/schema.ts
+++ b/packages/domain/src/tutor/schema.ts
@@ -1,0 +1,283 @@
+import { Effect, Schema } from "effect";
+
+const IdentifierSchema = Schema.NonEmptyString;
+const PositiveIntegerSchema = Schema.Int.check(
+  Schema.isBetween({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER }),
+);
+const ScoreValueSchema = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 10 }));
+const Rfc3339Schema = Schema.String.check(
+  Schema.isPattern(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/),
+);
+
+export const DepartmentIdSchema = IdentifierSchema;
+export type DepartmentId = typeof DepartmentIdSchema.Type;
+
+export const PersonIdSchema = IdentifierSchema;
+export type PersonId = typeof PersonIdSchema.Type;
+
+export const SemesterTermSchema = Schema.Union([Schema.Literal("Vår"), Schema.Literal("Høst")]);
+export type SemesterTerm = typeof SemesterTermSchema.Type;
+
+export const SemesterSchema = Schema.Struct({
+  year: Schema.Int,
+  term: SemesterTermSchema,
+});
+export type Semester = typeof SemesterSchema.Type;
+
+export const CycleSchema = Schema.Struct({
+  departmentId: DepartmentIdSchema,
+  semester: SemesterSchema,
+});
+export type Cycle = typeof CycleSchema.Type;
+
+export const StreamKeySchema = Schema.Struct({
+  personId: PersonIdSchema,
+  cycle: CycleSchema,
+});
+export type StreamKey = typeof StreamKeySchema.Type;
+
+export const SuitabilitySchema = Schema.Union([
+  Schema.Literal("Ja"),
+  Schema.Literal("Kanskje"),
+  Schema.Literal("Nei"),
+]);
+export type Suitability = typeof SuitabilitySchema.Type;
+
+export const AnswersSchema = Schema.Struct({
+  "q-0014-a": Schema.String,
+  "q-0014-b": Schema.String,
+});
+export type Answers = typeof AnswersSchema.Type;
+
+const ScoreFields = {
+  explanatoryPower: ScoreValueSchema,
+  roleModel: ScoreValueSchema,
+  suitability: ScoreValueSchema,
+  suitableAssistant: SuitabilitySchema,
+  answers: AnswersSchema,
+};
+
+export const InterviewScoreSchema = Schema.Struct(ScoreFields);
+export type InterviewScore = typeof InterviewScoreSchema.Type;
+
+export const ConductedInterviewScoreSchema = Schema.Struct({
+  ...ScoreFields,
+  conductedAt: Rfc3339Schema,
+});
+export type ConductedInterviewScore = typeof ConductedInterviewScoreSchema.Type;
+
+const EventEnvelopeFields = {
+  schemaVersion: Schema.Literal(1),
+  eventId: IdentifierSchema,
+  stream: StreamKeySchema,
+  streamVersion: PositiveIntegerSchema,
+  occurredAt: Rfc3339Schema,
+  causationId: IdentifierSchema,
+  correlationId: IdentifierSchema,
+};
+
+export const EmptyEventPayloadSchema = Schema.Struct({});
+export type EmptyEventPayload = typeof EmptyEventPayloadSchema.Type;
+
+export const InterviewConductedPayloadSchema = Schema.Struct({
+  scores: ConductedInterviewScoreSchema,
+});
+export type InterviewConductedPayload = typeof InterviewConductedPayloadSchema.Type;
+
+const ApplicationReceivedEventSchema = Schema.Struct({
+  ...EventEnvelopeFields,
+  eventType: Schema.Literal("ApplicationReceived"),
+  payload: EmptyEventPayloadSchema,
+});
+const InterviewInvitedEventSchema = Schema.Struct({
+  ...EventEnvelopeFields,
+  eventType: Schema.Literal("InterviewInvited"),
+  payload: EmptyEventPayloadSchema,
+});
+const InterviewAcceptedEventSchema = Schema.Struct({
+  ...EventEnvelopeFields,
+  eventType: Schema.Literal("InterviewAccepted"),
+  payload: EmptyEventPayloadSchema,
+});
+const InterviewConductedEventSchema = Schema.Struct({
+  ...EventEnvelopeFields,
+  eventType: Schema.Literal("InterviewConducted"),
+  payload: InterviewConductedPayloadSchema,
+});
+
+export const EventEnvelopeV1Schema = Schema.Union([
+  ApplicationReceivedEventSchema,
+  InterviewInvitedEventSchema,
+  InterviewAcceptedEventSchema,
+  InterviewConductedEventSchema,
+]);
+export type EventEnvelopeV1 = typeof EventEnvelopeV1Schema.Type;
+
+export const EventTypeSchema = Schema.Union([
+  Schema.Literal("ApplicationReceived"),
+  Schema.Literal("InterviewInvited"),
+  Schema.Literal("InterviewAccepted"),
+  Schema.Literal("InterviewConducted"),
+]);
+export type EventType = typeof EventTypeSchema.Type;
+
+export const ConductInterviewV1Schema = Schema.Struct({
+  schemaVersion: Schema.Literal(1),
+  commandId: IdentifierSchema,
+  correlationId: IdentifierSchema,
+  stream: StreamKeySchema,
+  expectedVersion: Schema.Int.check(
+    Schema.isBetween({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
+  ),
+  scores: InterviewScoreSchema,
+});
+export type ConductInterviewV1 = typeof ConductInterviewV1Schema.Type;
+
+export class TutorDecodeError extends Error {
+  readonly _tag = "DecodeError";
+  readonly reasonCode = "DECODE_ERROR";
+
+  constructor(readonly subject: "command" | "event" | "evidence") {
+    super(`closed ${subject} schema rejected input`);
+    this.name = "TutorDecodeError";
+  }
+}
+
+export const decodeConductInterviewV1 = (input: unknown) =>
+  Schema.decodeUnknownEffect(ConductInterviewV1Schema, { onExcessProperty: "error" })(input).pipe(
+    Effect.mapError(() => new TutorDecodeError("command")),
+  );
+
+export const decodeEventEnvelopeV1 = (input: unknown) =>
+  Schema.decodeUnknownEffect(EventEnvelopeV1Schema, { onExcessProperty: "error" })(input).pipe(
+    Effect.mapError(() => new TutorDecodeError("event")),
+  );
+
+export const DescriptorSchema = Schema.Struct({
+  descriptorVersion: Schema.Literal(1),
+  kind: Schema.Literal("InterviewConductedDescriptor"),
+  sourceEventId: IdentifierSchema,
+  causationId: IdentifierSchema,
+  correlationId: IdentifierSchema,
+  idempotencyKey: IdentifierSchema,
+});
+export type Descriptor = typeof DescriptorSchema.Type;
+
+export const ProjectionStatusSchema = Schema.Union([
+  Schema.Literal("received"),
+  Schema.Literal("invited"),
+  Schema.Literal("accepted"),
+  Schema.Literal("completed"),
+]);
+export type ProjectionStatus = typeof ProjectionStatusSchema.Type;
+export const LawRefSchema = Schema.Union([
+  Schema.Literal("T-INT-1"),
+  Schema.Literal("S-INT-1"),
+  Schema.Literal("T-INT-2"),
+  Schema.Literal("R-APP-1"),
+]);
+export type LawRef = typeof LawRefSchema.Type;
+
+export const ReasonCodeSchema = Schema.Union([
+  Schema.Literal("EMPTY_STREAM"),
+  Schema.Literal("DECODE_ERROR"),
+  Schema.Literal("STREAM_MISMATCH"),
+  Schema.Literal("STALE_VERSION"),
+  Schema.Literal("CONDUCT_REQUIRES_ACCEPTED"),
+  Schema.Literal("TERMINAL_CONDUCTED"),
+  Schema.Literal("CANONICAL_SEQUENCE"),
+  Schema.Literal("STREAM_VERSION_GAP"),
+  Schema.Literal("OCCURRED_AT_REWIND"),
+  Schema.Literal("DUPLICATE_EVENT_ID"),
+  Schema.Literal("DUPLICATE_COMMAND_CONFLICT"),
+  Schema.Literal("SEED_ACCEPTED"),
+  Schema.Literal("COMMAND_DECODED"),
+  Schema.Literal("INTERVIEW_CONDUCTED"),
+  Schema.Literal("DUPLICATE_IDEMPOTENT"),
+  Schema.Literal("EVIDENCE_REPEATABLE"),
+]);
+export type ReasonCode = typeof ReasonCodeSchema.Type;
+
+export const ProjectionSchema = Schema.Struct({
+  projectionVersion: Schema.Literal(1),
+  stream: StreamKeySchema,
+  streamVersion: PositiveIntegerSchema,
+  status: ProjectionStatusSchema,
+  eventTypes: Schema.Array(EventTypeSchema),
+  conductedAt: Schema.optional(Rfc3339Schema),
+  lawRefs: Schema.Array(LawRefSchema),
+});
+
+export type Projection = typeof ProjectionSchema.Type;
+
+export const EvidenceCaseStatusSchema = Schema.Union([
+  Schema.Literal("accepted"),
+  Schema.Literal("rejected"),
+  Schema.Literal("stale"),
+  Schema.Literal("terminal"),
+  Schema.Literal("duplicate"),
+  Schema.Literal("duplicate-conflict"),
+]);
+export type EvidenceCaseStatus = typeof EvidenceCaseStatusSchema.Type;
+
+export const EvidenceCaseSchema = Schema.Struct({
+  caseId: IdentifierSchema,
+  status: EvidenceCaseStatusSchema,
+  reasonCode: ReasonCodeSchema,
+  commandId: IdentifierSchema,
+  streamVersion: Schema.Int.check(
+    Schema.isBetween({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
+  ),
+  eventCount: Schema.Int.check(
+    Schema.isBetween({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
+  ),
+  descriptorCount: Schema.Int.check(
+    Schema.isBetween({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
+  ),
+});
+export type EvidenceCase = typeof EvidenceCaseSchema.Type;
+
+export const CounterexampleReceiptSchema = Schema.Struct({
+  caseId: IdentifierSchema,
+  expectedReasonCode: ReasonCodeSchema,
+  observedReasonCode: ReasonCodeSchema,
+  preservedEventCount: Schema.Int.check(
+    Schema.isBetween({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
+  ),
+  preservedDescriptorCount: Schema.Int.check(
+    Schema.isBetween({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
+  ),
+});
+export type CounterexampleReceipt = typeof CounterexampleReceiptSchema.Type;
+
+export const ProvenanceSchema = Schema.Struct({
+  effectSource: Schema.Literal("local-effect-source"),
+  effectVersion: Schema.Literal("4.0.0-beta.107"),
+  effectSourceHash: Schema.String.check(Schema.isPattern(/^[a-f0-9]{40}$/)),
+  sourceCommandId: IdentifierSchema,
+  eventIds: Schema.Array(IdentifierSchema),
+  limits: Schema.Array(IdentifierSchema),
+  counterexampleReceipts: Schema.Array(CounterexampleReceiptSchema),
+});
+export type Provenance = typeof ProvenanceSchema.Type;
+
+export const EvidenceSchema = Schema.Struct({
+  formatVersion: Schema.Literal(1),
+  specId: Schema.Literal("0014"),
+  baseCommit: IdentifierSchema,
+  fixtureId: IdentifierSchema,
+  schemaVersion: Schema.Literal(1),
+  correlationId: IdentifierSchema,
+  stream: StreamKeySchema,
+  cases: Schema.Array(EvidenceCaseSchema),
+  projection: ProjectionSchema,
+  eventIds: Schema.Array(IdentifierSchema),
+  effectDescriptors: Schema.Array(DescriptorSchema),
+  provenance: ProvenanceSchema,
+});
+export type Evidence = typeof EvidenceSchema.Type;
+
+export const decodeEvidence = (input: unknown) =>
+  Schema.decodeUnknownEffect(EvidenceSchema, { onExcessProperty: "error" })(input).pipe(
+    Effect.mapError(() => new TutorDecodeError("evidence")),
+  );

--- a/packages/domain/src/tutor/tracer.ts
+++ b/packages/domain/src/tutor/tracer.ts
@@ -1,0 +1,370 @@
+import { Effect } from "effect";
+import {
+  type ConductInterviewV1,
+  decodeConductInterviewV1,
+  decodeEventEnvelopeV1,
+  type Descriptor,
+  type EventEnvelopeV1,
+  type EventType,
+  type Projection,
+  type ProjectionStatus,
+  type StreamKey,
+  type TutorDecodeError,
+} from "./schema.js";
+import { canonicalJson } from "./evidence.js";
+
+export const FIXTURE_CONDUCTED_AT = "2026-08-11T09:03:00Z";
+
+export class StreamMismatch extends Error {
+  readonly _tag = "StreamMismatch";
+  readonly reasonCode = "STREAM_MISMATCH";
+
+  constructor(readonly detail: "COMMAND_STREAM" | "COMMAND_CORRELATION" | "EVENT_STREAM" | "EVENT_CORRELATION" | "STATE_STREAM") {
+    super(`stream identity rejected (${detail})`);
+    this.name = "StreamMismatch";
+  }
+}
+
+export class StaleState extends Error {
+  readonly _tag = "StaleState";
+  readonly reasonCode = "STALE_VERSION";
+
+  constructor(readonly expectedVersion: number, readonly currentVersion: number) {
+    super("expected stream version is stale");
+    this.name = "StaleState";
+  }
+}
+
+export class InvalidTransition extends Error {
+  readonly _tag = "InvalidTransition";
+
+  constructor(
+    readonly reasonCode:
+      | "EMPTY_STREAM"
+      | "CANONICAL_SEQUENCE"
+      | "CONDUCT_REQUIRES_ACCEPTED"
+      | "TERMINAL_CONDUCTED",
+    readonly lawRef: "T-INT-1" | "T-INT-2" | undefined,
+  ) {
+    super(`transition rejected (${reasonCode})`);
+    this.name = "InvalidTransition";
+  }
+}
+
+export class OutOfOrderEvent extends Error {
+  readonly _tag = "OutOfOrderEvent";
+
+  constructor(readonly reasonCode: "STREAM_VERSION_GAP" | "OCCURRED_AT_REWIND") {
+    super(`event order rejected (${reasonCode})`);
+    this.name = "OutOfOrderEvent";
+  }
+}
+
+export class DuplicateEvent extends Error {
+  readonly _tag = "DuplicateEvent";
+  readonly reasonCode = "DUPLICATE_EVENT_ID";
+
+  constructor(readonly eventId: string) {
+    super("duplicate event identity rejected");
+    this.name = "DuplicateEvent";
+  }
+}
+
+export class DuplicateCommandConflict extends Error {
+  readonly _tag = "DuplicateCommandConflict";
+  readonly reasonCode = "DUPLICATE_COMMAND_CONFLICT";
+
+  constructor(readonly commandId: string) {
+    super("duplicate command body conflict");
+    this.name = "DuplicateCommandConflict";
+  }
+}
+
+export type TutorFailure =
+  | TutorDecodeError
+  | StreamMismatch
+  | StaleState
+  | InvalidTransition
+  | OutOfOrderEvent
+  | DuplicateEvent
+  | DuplicateCommandConflict;
+
+export interface FoldedState {
+  readonly stream: StreamKey;
+  readonly correlationId: string;
+  readonly events: ReadonlyArray<EventEnvelopeV1>;
+  readonly nextEventType: EventType | "Terminal";
+}
+
+export interface CommandObservation {
+  readonly outcome: "accepted";
+  readonly commandId: string;
+  readonly eventId: string;
+  readonly streamVersion: number;
+  readonly eventCount: number;
+  readonly descriptorCount: 1;
+  readonly projection: Projection;
+  readonly descriptor: Descriptor;
+}
+
+export interface CommandReceipt {
+  readonly commandId: string;
+  readonly commandBytes: string;
+  readonly observationBytes: string;
+  readonly observation: CommandObservation;
+}
+
+export interface TutorState {
+  readonly stream: StreamKey;
+  readonly events: ReadonlyArray<EventEnvelopeV1>;
+  readonly receipts: ReadonlyArray<CommandReceipt>;
+}
+
+export interface AcceptedResult {
+  readonly _tag: "AcceptedResult";
+  readonly state: TutorState;
+  readonly observation: CommandObservation;
+  readonly observationBytes: string;
+}
+
+export interface DuplicateResult {
+  readonly _tag: "DuplicateResult";
+  readonly state: TutorState;
+  readonly observation: CommandObservation;
+  readonly observationBytes: string;
+}
+
+export type ConductInterviewResult = AcceptedResult | DuplicateResult;
+
+const streamEqual = (left: StreamKey, right: StreamKey): boolean =>
+  left.personId === right.personId &&
+  left.cycle.departmentId === right.cycle.departmentId &&
+  left.cycle.semester.year === right.cycle.semester.year &&
+  left.cycle.semester.term === right.cycle.semester.term;
+
+const expectedEventType = (index: number): EventType | "Terminal" => {
+  switch (index) {
+    case 0:
+      return "ApplicationReceived";
+    case 1:
+      return "InterviewInvited";
+    case 2:
+      return "InterviewAccepted";
+    case 3:
+      return "InterviewConducted";
+    default:
+      return "Terminal";
+  }
+};
+
+export const foldEvents = (inputs: ReadonlyArray<unknown>): Effect.Effect<FoldedState, TutorFailure> =>
+  Effect.gen(function* () {
+    if (inputs.length === 0) {
+      return yield* Effect.fail(new InvalidTransition("EMPTY_STREAM", undefined));
+    }
+
+    const events: Array<EventEnvelopeV1> = [];
+    const eventIds = new Set<string>();
+    let stream: StreamKey | undefined;
+    let correlationId: string | undefined;
+    let previousOccurredAt: string | undefined;
+
+    for (const input of inputs) {
+      const event = yield* decodeEventEnvelopeV1(input);
+      const index = events.length;
+      const expectedVersion = index + 1;
+      const expectedType = expectedEventType(index);
+
+      if (eventIds.has(event.eventId)) {
+        return yield* Effect.fail(new DuplicateEvent(event.eventId));
+      }
+      if (event.streamVersion !== expectedVersion) {
+        return yield* Effect.fail(new OutOfOrderEvent("STREAM_VERSION_GAP"));
+      }
+      if (previousOccurredAt !== undefined && event.occurredAt < previousOccurredAt) {
+        return yield* Effect.fail(new OutOfOrderEvent("OCCURRED_AT_REWIND"));
+      }
+      if (stream === undefined) {
+        stream = event.stream;
+        correlationId = event.correlationId;
+      } else if (!streamEqual(stream, event.stream)) {
+        return yield* Effect.fail(new StreamMismatch("EVENT_STREAM"));
+      } else if (event.correlationId !== correlationId) {
+        return yield* Effect.fail(new StreamMismatch("EVENT_CORRELATION"));
+      }
+      if (expectedType === "Terminal" || event.eventType !== expectedType) {
+        return yield* Effect.fail(new InvalidTransition("CANONICAL_SEQUENCE", "T-INT-1"));
+      }
+
+      eventIds.add(event.eventId);
+      events.push(event);
+      previousOccurredAt = event.occurredAt;
+    }
+
+    const firstEvent = events[0];
+    if (firstEvent === undefined || stream === undefined || correlationId === undefined) {
+      return yield* Effect.fail(new InvalidTransition("EMPTY_STREAM", undefined));
+    }
+
+    return {
+      stream,
+      correlationId,
+      events,
+      nextEventType: expectedEventType(events.length),
+    };
+  });
+
+export const createTutorState = (inputs: ReadonlyArray<unknown>): Effect.Effect<TutorState, TutorFailure> =>
+  Effect.map(foldEvents(inputs), (folded) => ({
+    stream: folded.stream,
+    events: folded.events,
+    receipts: [],
+  }));
+
+const projectionStatus = (eventType: EventType): ProjectionStatus => {
+  switch (eventType) {
+    case "ApplicationReceived":
+      return "received";
+    case "InterviewInvited":
+      return "invited";
+    case "InterviewAccepted":
+      return "accepted";
+    case "InterviewConducted":
+      return "completed";
+  }
+};
+
+export const projectFoldedState = (folded: FoldedState): Projection => {
+  const lastEvent = folded.events[folded.events.length - 1];
+  if (lastEvent === undefined) {
+    throw new Error("cannot project an empty folded state");
+  }
+
+  const base: Omit<Projection, "conductedAt"> = {
+    projectionVersion: 1,
+    stream: folded.stream,
+    streamVersion: folded.events.length,
+    status: projectionStatus(lastEvent.eventType),
+    eventTypes: folded.events.map((event) => event.eventType),
+    lawRefs: ["T-INT-1", "S-INT-1", "T-INT-2", "R-APP-1"],
+  };
+
+  if (lastEvent.eventType === "InterviewConducted") {
+    return {
+      ...base,
+      conductedAt: lastEvent.payload.scores.conductedAt,
+    };
+  }
+  return base;
+};
+
+const conductEvent = (command: ConductInterviewV1, folded: FoldedState): EventEnvelopeV1 => ({
+  schemaVersion: 1,
+  eventId: `evt-0014-${String(folded.events.length + 1).padStart(3, "0")}`,
+  stream: command.stream,
+  streamVersion: folded.events.length + 1,
+  eventType: "InterviewConducted",
+  payload: {
+    scores: {
+      ...command.scores,
+      conductedAt: FIXTURE_CONDUCTED_AT,
+    },
+  },
+  occurredAt: FIXTURE_CONDUCTED_AT,
+  causationId: command.commandId,
+  correlationId: command.correlationId,
+});
+
+const observationFor = (
+  command: ConductInterviewV1,
+  event: EventEnvelopeV1,
+  projection: Projection,
+  descriptor: Descriptor,
+): CommandObservation => ({
+  outcome: "accepted",
+  commandId: command.commandId,
+  eventId: event.eventId,
+  streamVersion: projection.streamVersion,
+  eventCount: projection.streamVersion,
+  descriptorCount: 1,
+  projection,
+  descriptor,
+});
+
+export const conductInterview = (
+  state: TutorState,
+  input: unknown,
+): Effect.Effect<ConductInterviewResult, TutorFailure> =>
+  Effect.gen(function* () {
+    const command = yield* decodeConductInterviewV1(input);
+    const commandBytes = canonicalJson(command);
+    const receipt = state.receipts.find((candidate) => candidate.commandId === command.commandId);
+
+    if (receipt !== undefined) {
+      if (receipt.commandBytes === commandBytes) {
+        return {
+          _tag: "DuplicateResult",
+          state,
+          observation: receipt.observation,
+          observationBytes: receipt.observationBytes,
+        };
+      }
+      return yield* Effect.fail(new DuplicateCommandConflict(command.commandId));
+    }
+
+    const folded = yield* foldEvents(state.events);
+    if (!streamEqual(state.stream, folded.stream)) {
+      return yield* Effect.fail(new StreamMismatch("STATE_STREAM"));
+    }
+    if (!streamEqual(command.stream, folded.stream)) {
+      return yield* Effect.fail(new StreamMismatch("COMMAND_STREAM"));
+    }
+    if (command.correlationId !== folded.correlationId) {
+      return yield* Effect.fail(new StreamMismatch("COMMAND_CORRELATION"));
+    }
+    if (command.expectedVersion !== folded.events.length) {
+      return yield* Effect.fail(new StaleState(command.expectedVersion, folded.events.length));
+    }
+    if (folded.nextEventType === "Terminal") {
+      return yield* Effect.fail(new InvalidTransition("TERMINAL_CONDUCTED", "T-INT-2"));
+    }
+    if (folded.nextEventType !== "InterviewConducted") {
+      return yield* Effect.fail(new InvalidTransition("CONDUCT_REQUIRES_ACCEPTED", "T-INT-1"));
+    }
+
+    const event = conductEvent(command, folded);
+    const nextEvents = [...folded.events, event];
+    const nextFolded = yield* foldEvents(nextEvents);
+    const projection = projectFoldedState(nextFolded);
+    const descriptor: Descriptor = {
+      descriptorVersion: 1,
+      kind: "InterviewConductedDescriptor",
+      sourceEventId: event.eventId,
+      causationId: command.commandId,
+      correlationId: command.correlationId,
+      idempotencyKey: `post-commit:${event.eventId}`,
+    };
+    const observation = observationFor(command, event, projection, descriptor);
+    const observationBytes = canonicalJson(observation);
+    const nextState: TutorState = {
+      stream: nextFolded.stream,
+      events: nextFolded.events,
+      receipts: [
+        ...state.receipts,
+        {
+          commandId: command.commandId,
+          commandBytes,
+          observationBytes,
+          observation,
+        },
+      ],
+    };
+
+    return {
+      _tag: "AcceptedResult",
+      state: nextState,
+      observation,
+      observationBytes,
+    };
+  });
+


### PR DESCRIPTION
## Design spec
`design-specs/0014-tutor-event-envelope-tracer.md`

## Journey
A maintainer runs a deterministic tutor lifecycle tracer that decodes commands, accepts lawful transitions, rejects stale or illegal transitions, and emits replayable envelopes and receipts.

## Experience it
1. Check out this stacked branch.
2. Run the focused package commands recorded in the spec.
3. Inspect accepted and rejected transition evidence and two-run byte identity.

## Evidence
- Focused build, typecheck, lint, and proof gates: PASS.
- Independent code/runtime review: PASS.
- Exact eight-path capsule including the final spec.

## What is real
The in-memory command/event/receipt seam is executable and deterministic. It does not claim D1 persistence, Worker routing, scheduling semantics, provider behavior, deployment, or production acceptance.
