### PR TITLE
feat(domain): prove the tutor D1 event-store seam

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
         "@tailwindcss/vite": "^4.0.17",
         "@tanstack/react-query": "^5",
         "@tanstack/react-table": "^8.21.2",
-        "@vektorprogrammet/sdk": "^0.1.2",
+        "@vektorprogrammet/sdk": "workspace:*",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -146,8 +146,13 @@
     "packages/domain": {
       "name": "@vektorprogrammet/domain",
       "version": "0.1.0",
+      "dependencies": {
+        "@effect/sql-d1": "4.0.0-beta.107",
+        "effect": "4.0.0-beta.107",
+      },
       "devDependencies": {
         "@types/node": "^22",
+        "miniflare": "4.20260706.0",
         "oxlint": "^1.41.0",
         "typescript": "^5",
       },
@@ -426,7 +431,9 @@
 
     "@discoveryjs/json-ext": ["@discoveryjs/json-ext@0.5.7", "", {}, "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
+    "@effect/sql-d1": ["@effect/sql-d1@4.0.0-beta.107", "", { "dependencies": { "@cloudflare/workers-types": "^5.20260708.1" }, "peerDependencies": { "effect": "^4.0.0-beta.107" } }, "sha512-GN0RMZRQ+Kc6t4hiIbGBFMdYj2UssX27w0n1oyV+s9OZcWOdD42C2vDxUwnnKLstPDdeOMBAFX7dMekOiF2rUQ=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
@@ -496,57 +503,57 @@
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.1" }, "os": "darwin", "cpu": "arm64" }, "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg=="],
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
 
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.1" }, "os": "darwin", "cpu": "x64" }, "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw=="],
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
 
     "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.2", "", { "dependencies": { "@img/sharp-wasm32": "0.35.2" }, "os": "freebsd" }, "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw=="],
 
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g=="],
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
 
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ=="],
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
 
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.1", "", { "os": "linux", "cpu": "arm" }, "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg=="],
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
 
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw=="],
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
 
-    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng=="],
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
 
-    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.1", "", { "os": "linux", "cpu": "none" }, "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw=="],
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
 
-    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew=="],
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
 
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A=="],
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
 
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw=="],
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
 
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg=="],
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
 
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.1" }, "os": "linux", "cpu": "arm" }, "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A=="],
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
 
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA=="],
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
 
-    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.1" }, "os": "linux", "cpu": "ppc64" }, "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg=="],
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
 
-    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.1" }, "os": "linux", "cpu": "none" }, "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA=="],
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
 
-    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.1" }, "os": "linux", "cpu": "s390x" }, "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA=="],
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
 
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA=="],
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
 
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg=="],
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
 
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg=="],
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
 
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.2", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw=="],
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
 
     "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.2", "", { "dependencies": { "@img/sharp-wasm32": "0.35.2" }, "cpu": "none" }, "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g=="],
 
-    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ=="],
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
 
-    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog=="],
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
 
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.2", "", { "os": "win32", "cpu": "x64" }, "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ=="],
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
@@ -1456,7 +1463,7 @@
 
     "is-windows": ["is-windows@1.0.2", "", {}, "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="],
 
-    "isbot": ["isbot@5.1.35", "", {}, "sha512-waFfC72ZNfwLLuJ2iLaoVaqcNo+CAaLR7xCpAn0Y5WfGzkNHv7ZN39Vbi1y+kb+Zs46XHOX3tZNExroFUPX+Kg=="],
+    "isbot": ["isbot@5.2.1", "", {}, "sha512-dJ+LpKyClQZ7NG+j3OensC/mAZkGpukE9YUrgPYvAZj2doVL0edfDgywTUh5CXa0o+nW9a1V9e5+CJTX8+SxRw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -1572,7 +1579,7 @@
 
     "min-document": ["min-document@2.19.2", "", { "dependencies": { "dom-walk": "^0.1.0" } }, "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A=="],
 
-    "miniflare": ["miniflare@5.20260804.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260804.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-UDegnTukIpJCI/lNyQXU7B8kYFLcMZihlxqqOocnc62tV8AO6XofmFmZm3ZLDXTWZpkZnLLJ2sKCSlTIEXO3dQ=="],
+    "miniflare": ["miniflare@4.20260706.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260706.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-UiqGo9Es/D7kJvDVpjhTQ/M2ppCSCsRc5EEKec6i4BvnCkFCRaZHRmFkMHzLhlg+daSZ+zvBaycWmgLZHn/1tQ=="],
 
     "minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
@@ -1639,12 +1646,6 @@
     "on-headers": ["on-headers@1.1.0", "", {}, "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A=="],
 
     "openai": ["openai@4.104.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" }, "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA=="],
-
-    "openapi-fetch": ["openapi-fetch@0.13.8", "", { "dependencies": { "openapi-typescript-helpers": "^0.0.15" } }, "sha512-yJ4QKRyNxE44baQ9mY5+r/kAzZ8yXMemtNAOFwOzRXJscdjSxxzWSNlyBAr+o5JjkUw9Lc3W7OIoca0cY3PYnQ=="],
-
-    "openapi-react-query": ["openapi-react-query@0.3.2", "", { "dependencies": { "openapi-typescript-helpers": "^0.0.15" }, "peerDependencies": { "@tanstack/react-query": "^5.25.0", "openapi-fetch": "^0.13.6" } }, "sha512-nJq1Fpt0PwO0KeJf+pL5s5m9ecIaWmaFqkfrxwMOKMEEP2yLuOW4pb0UzSxkYIAq9dlQHiHpYCHu0tb7F0kSkA=="],
-
-    "openapi-typescript-helpers": ["openapi-typescript-helpers@0.0.15", "", {}, "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw=="],
 
     "opener": ["opener@1.5.2", "", { "bin": { "opener": "bin/opener-bin.js" } }, "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A=="],
 
@@ -1780,9 +1781,9 @@
 
     "raw-body": ["raw-body@2.5.3", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "unpipe": "~1.0.0" } }, "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA=="],
 
-    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
+    "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
 
-    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+    "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
 
     "react-hook-form": ["react-hook-form@7.71.2", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA=="],
 
@@ -1862,7 +1863,7 @@
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
-    "sharp": ["sharp@0.35.2", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.4" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.2", "@img/sharp-darwin-x64": "0.35.2", "@img/sharp-freebsd-wasm32": "0.35.2", "@img/sharp-libvips-darwin-arm64": "1.3.1", "@img/sharp-libvips-darwin-x64": "1.3.1", "@img/sharp-libvips-linux-arm": "1.3.1", "@img/sharp-libvips-linux-arm64": "1.3.1", "@img/sharp-libvips-linux-ppc64": "1.3.1", "@img/sharp-libvips-linux-riscv64": "1.3.1", "@img/sharp-libvips-linux-s390x": "1.3.1", "@img/sharp-libvips-linux-x64": "1.3.1", "@img/sharp-libvips-linuxmusl-arm64": "1.3.1", "@img/sharp-libvips-linuxmusl-x64": "1.3.1", "@img/sharp-linux-arm": "0.35.2", "@img/sharp-linux-arm64": "0.35.2", "@img/sharp-linux-ppc64": "0.35.2", "@img/sharp-linux-riscv64": "0.35.2", "@img/sharp-linux-s390x": "0.35.2", "@img/sharp-linux-x64": "0.35.2", "@img/sharp-linuxmusl-arm64": "0.35.2", "@img/sharp-linuxmusl-x64": "0.35.2", "@img/sharp-webcontainers-wasm32": "0.35.2", "@img/sharp-win32-arm64": "0.35.2", "@img/sharp-win32-ia32": "0.35.2", "@img/sharp-win32-x64": "0.35.2" } }, "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w=="],
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -2004,7 +2005,7 @@
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
-    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -2110,7 +2111,13 @@
 
     "@changesets/write/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
+    "@cloudflare/vite-plugin/miniflare": ["miniflare@5.20260804.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260804.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-UDegnTukIpJCI/lNyQXU7B8kYFLcMZihlxqqOocnc62tV8AO6XofmFmZm3ZLDXTWZpkZnLLJ2sKCSlTIEXO3dQ=="],
+
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@img/sharp-freebsd-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.2", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw=="],
+
+    "@img/sharp-webcontainers-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.2", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
@@ -2120,19 +2127,11 @@
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
-    "@monoweb/dashboard/@vektorprogrammet/sdk": ["@vektorprogrammet/sdk@0.1.2", "", { "dependencies": { "openapi-fetch": "^0.13", "openapi-react-query": "^0.3" }, "peerDependencies": { "@tanstack/react-query": "^5", "react": "^18 || ^19" } }, "sha512-3dBn7iwynA6YfkbdhmB+3so2ZLFOJxEv98EFjAtRng7nUJIa3odQVcXT6T6xSVvbWVhU85d64Khsu/O1OMAQXA=="],
-
     "@monoweb/homepage/@react-router/dev": ["@react-router/dev@8.3.0", "", { "dependencies": { "@babel/core": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/plugin-syntax-jsx": "^7.29.7", "@babel/preset-typescript": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@react-router/node": "8.3.0", "@remix-run/node-fetch-server": "^0.13.3", "babel-dead-code-elimination": "^1.0.12", "chokidar": "^5.0.0", "dedent": "^1.7.2", "es-module-lexer": "^2.1.0", "exit-hook": "5.1.0", "isbot": "^5.1.40", "jsesc": "3.1.0", "lodash": "^4.18.1", "p-map": "^7.0.4", "pathe": "^2.0.3", "picocolors": "^1.1.1", "pkg-types": "^2.3.1", "prettier": "^3.8.3", "react-refresh": "^0.18.0", "semver": "^7.8.1", "tinyglobby": "^0.2.16", "valibot": "^1.4.1" }, "peerDependencies": { "@react-router/serve": "^8.3.0", "@vitejs/plugin-rsc": "~0.5.26", "react-router": "^8.3.0", "react-server-dom-webpack": "^19.2.7", "typescript": "^5.1.0 || ^6.0.0 || ^7.0.0", "vite": "^7.0.0 || ^8.0.0", "wrangler": "^4.0.0" }, "optionalPeers": ["@react-router/serve", "@vitejs/plugin-rsc", "react-server-dom-webpack", "typescript", "wrangler"], "bin": { "react-router": "bin.cjs" } }, "sha512-XR+N2fEFOPjczYo2efc3/AOtosbSICCroLF/IxnZ6ErGBeBGRG6SqAso0SYoff0e18OA05qOyhJHFhXKMGIPRw=="],
 
     "@monoweb/homepage/@react-router/fs-routes": ["@react-router/fs-routes@8.3.0", "", { "dependencies": { "minimatch": "^10.2.5" }, "peerDependencies": { "@react-router/dev": "^8.3.0", "typescript": "^5.1.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rElHqQQr4XO0bh2VXEBWtJvVWc2340EoZNL29qwLeZPvUTgAZDI2x/x/VnHNSiEYIMvKTJQziKM7krzWCydN8A=="],
 
     "@monoweb/homepage/@react-router/node": ["@react-router/node@8.3.0", "", { "dependencies": { "@remix-run/node-fetch-server": "^0.13.3" }, "peerDependencies": { "react-router": "8.3.0", "typescript": "^5.1.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["typescript"] }, "sha512-qw5ibcolE1OcwngiEw6t7LR11Hi6yWEDvj6cfvaYROX+w18JPxc0YSmsdn3Wlc9TOX+Qo8FVcxbXRdc9vojn2w=="],
-
-    "@monoweb/homepage/isbot": ["isbot@5.2.1", "", {}, "sha512-dJ+LpKyClQZ7NG+j3OensC/mAZkGpukE9YUrgPYvAZj2doVL0edfDgywTUh5CXa0o+nW9a1V9e5+CJTX8+SxRw=="],
-
-    "@monoweb/homepage/react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
-
-    "@monoweb/homepage/react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
 
     "@monoweb/homepage/react-router": ["react-router@8.3.0", "", { "dependencies": { "cookie-es": "^3.1.1" }, "peerDependencies": { "react": ">=19.2.7", "react-dom": ">=19.2.7" }, "optionalPeers": ["react-dom"] }, "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ=="],
 
@@ -2167,6 +2166,8 @@
     "@radix-ui/react-separator/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@react-router/dev/isbot": ["isbot@5.1.35", "", {}, "sha512-waFfC72ZNfwLLuJ2iLaoVaqcNo+CAaLR7xCpAn0Y5WfGzkNHv7ZN39Vbi1y+kb+Zs46XHOX3tZNExroFUPX+Kg=="],
 
     "@tailwindcss/node/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
@@ -2228,13 +2229,13 @@
 
     "mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
+    "miniflare/workerd": ["workerd@1.20260706.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260706.1", "@cloudflare/workerd-darwin-arm64": "1.20260706.1", "@cloudflare/workerd-linux-64": "1.20260706.1", "@cloudflare/workerd-linux-arm64": "1.20260706.1", "@cloudflare/workerd-windows-64": "1.20260706.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-0DOmgysJiPZRwtlg9Bh70aDnHuVech70fKVM4721RbdfewL29ODxn4TpgkusybLYrQAkgHkW53SUt2AdkBa+Og=="],
+
     "morgan/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "morgan/on-finished": ["on-finished@2.3.0", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
-
-    "next/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "niva-ui/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
@@ -2263,8 +2264,6 @@
     "sanskrit-lang/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
-
-    "sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "showdown/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 
@@ -2295,6 +2294,16 @@
     "webpack-bundle-analyzer/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
     "webpack-bundle-analyzer/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
+    "wrangler/miniflare": ["miniflare@5.20260804.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260804.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-UDegnTukIpJCI/lNyQXU7B8kYFLcMZihlxqqOocnc62tV8AO6XofmFmZm3ZLDXTWZpkZnLLJ2sKCSlTIEXO3dQ=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp": ["sharp@0.35.2", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.4" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.2", "@img/sharp-darwin-x64": "0.35.2", "@img/sharp-freebsd-wasm32": "0.35.2", "@img/sharp-libvips-darwin-arm64": "1.3.1", "@img/sharp-libvips-darwin-x64": "1.3.1", "@img/sharp-libvips-linux-arm": "1.3.1", "@img/sharp-libvips-linux-arm64": "1.3.1", "@img/sharp-libvips-linux-ppc64": "1.3.1", "@img/sharp-libvips-linux-riscv64": "1.3.1", "@img/sharp-libvips-linux-s390x": "1.3.1", "@img/sharp-libvips-linux-x64": "1.3.1", "@img/sharp-libvips-linuxmusl-arm64": "1.3.1", "@img/sharp-libvips-linuxmusl-x64": "1.3.1", "@img/sharp-linux-arm": "0.35.2", "@img/sharp-linux-arm64": "0.35.2", "@img/sharp-linux-ppc64": "0.35.2", "@img/sharp-linux-riscv64": "0.35.2", "@img/sharp-linux-s390x": "0.35.2", "@img/sharp-linux-x64": "0.35.2", "@img/sharp-linuxmusl-arm64": "0.35.2", "@img/sharp-linuxmusl-x64": "0.35.2", "@img/sharp-webcontainers-wasm32": "0.35.2", "@img/sharp-win32-arm64": "0.35.2", "@img/sharp-win32-ia32": "0.35.2", "@img/sharp-win32-x64": "0.35.2" } }, "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w=="],
+
+    "@cloudflare/vite-plugin/miniflare/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+
+    "@img/sharp-freebsd-wasm32/@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
+
+    "@img/sharp-webcontainers-wasm32/@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 
     "@monoweb/homepage/@react-router/dev/@babel/core": ["@babel/core@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-module-transforms": "^7.29.7", "@babel/helpers": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA=="],
 
@@ -2396,57 +2405,19 @@
 
     "markmind-editor/react-dom/scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
+    "miniflare/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260706.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-61XleG5EaE+Zam2Y/fwOcMInMrjd3QMKIG0/+pHycZcVZC5Oxs5GfHSTnvyhcniigGW/bcIkvn1PptWbxlVleQ=="],
+
+    "miniflare/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260706.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jbwuMEuhgrXEk+9MD8eHPRsXWlxqtNMqqCMBLJauTHk+NR+U2O6hJXElPqlAVlUTh0A0GPM+DfATupRXm7Ml8w=="],
+
+    "miniflare/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260706.1", "", { "os": "linux", "cpu": "x64" }, "sha512-kppCFkt6WHTNmcE83aUj4chWV13hdQKOgXxn53sqpLiVnPi6HEIOWB1DNRAljG9IDt3KMgni9HdzCYVzq2drJA=="],
+
+    "miniflare/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260706.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-H4xpocM1vXNfIVrP/JiOhLooWBXi5erE81hBj2wmCvPIUcf+49CuvZEthpVwFYn9SFop/Y8+bUiV0vVrWf8xuw=="],
+
+    "miniflare/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260706.1", "", { "os": "win32", "cpu": "x64" }, "sha512-SPWuI+kBNtr/mhcKE7XOECgRWOaidmzVmvtmDrRZX5Y4/+XqD/heRAU5Oa17wOZm3eQ1CB8Xzxjrr/6uQaP8YA=="],
+
     "morgan/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
-
-    "next/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
-
-    "next/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
-
-    "next/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
-
-    "next/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
-
-    "next/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
-
-    "next/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
-
-    "next/sharp/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
-
-    "next/sharp/@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
-
-    "next/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
-
-    "next/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
-
-    "next/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
-
-    "next/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
-
-    "next/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
-
-    "next/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
-
-    "next/sharp/@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
-
-    "next/sharp/@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
-
-    "next/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
-
-    "next/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
-
-    "next/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
-
-    "next/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
-
-    "next/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
-
-    "next/sharp/@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
-
-    "next/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
-
-    "next/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "notion-design-system/lucide-react/react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
@@ -2569,6 +2540,58 @@
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "vite/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "wrangler/miniflare/sharp": ["sharp@0.35.2", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.4" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.2", "@img/sharp-darwin-x64": "0.35.2", "@img/sharp-freebsd-wasm32": "0.35.2", "@img/sharp-libvips-darwin-arm64": "1.3.1", "@img/sharp-libvips-darwin-x64": "1.3.1", "@img/sharp-libvips-linux-arm": "1.3.1", "@img/sharp-libvips-linux-arm64": "1.3.1", "@img/sharp-libvips-linux-ppc64": "1.3.1", "@img/sharp-libvips-linux-riscv64": "1.3.1", "@img/sharp-libvips-linux-s390x": "1.3.1", "@img/sharp-libvips-linux-x64": "1.3.1", "@img/sharp-libvips-linuxmusl-arm64": "1.3.1", "@img/sharp-libvips-linuxmusl-x64": "1.3.1", "@img/sharp-linux-arm": "0.35.2", "@img/sharp-linux-arm64": "0.35.2", "@img/sharp-linux-ppc64": "0.35.2", "@img/sharp-linux-riscv64": "0.35.2", "@img/sharp-linux-s390x": "0.35.2", "@img/sharp-linux-x64": "0.35.2", "@img/sharp-linuxmusl-arm64": "0.35.2", "@img/sharp-linuxmusl-x64": "0.35.2", "@img/sharp-webcontainers-wasm32": "0.35.2", "@img/sharp-win32-arm64": "0.35.2", "@img/sharp-win32-ia32": "0.35.2", "@img/sharp-win32-x64": "0.35.2" } }, "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w=="],
+
+    "wrangler/miniflare/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.1" }, "os": "darwin", "cpu": "arm64" }, "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.1" }, "os": "darwin", "cpu": "x64" }, "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.1", "", { "os": "linux", "cpu": "arm" }, "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.1", "", { "os": "linux", "cpu": "none" }, "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.1" }, "os": "linux", "cpu": "arm" }, "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.1" }, "os": "linux", "cpu": "ppc64" }, "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.1" }, "os": "linux", "cpu": "none" }, "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.1" }, "os": "linux", "cpu": "s390x" }, "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.2", "", { "os": "win32", "cpu": "x64" }, "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ=="],
+
+    "@cloudflare/vite-plugin/miniflare/sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "@monoweb/homepage/@react-router/dev/@babel/core/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
@@ -2734,9 +2757,55 @@
 
     "@vitejs/plugin-legacy/vite/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "next/sharp/@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
-
     "vite-plugin-static-copy/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.1" }, "os": "darwin", "cpu": "arm64" }, "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.1" }, "os": "darwin", "cpu": "x64" }, "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.1", "", { "os": "linux", "cpu": "arm" }, "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.1", "", { "os": "linux", "cpu": "none" }, "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.1" }, "os": "linux", "cpu": "arm" }, "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.1" }, "os": "linux", "cpu": "ppc64" }, "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.1" }, "os": "linux", "cpu": "none" }, "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.1" }, "os": "linux", "cpu": "s390x" }, "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.2", "", { "os": "win32", "cpu": "x64" }, "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ=="],
+
+    "wrangler/miniflare/sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "@monoweb/homepage/@react-router/dev/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 

--- a/design-specs/0017-tutor-d1-event-store-proof.md
+++ b/design-specs/0017-tutor-d1-event-store-proof.md
@@ -1,0 +1,964 @@
+# Live design spec 0017 — tutor D1 event-store proof
+
+> **Summary:** One maintainer journey, implemented and proven locally on the canonical line, applies one deterministic schema migration to one disposable local Miniflare D1 binding, seeds the accepted 0014 stream, appends `InterviewConducted` as version 4 through the accepted `ConductInterview` transition, replays through the accepted pure fold, and records fail-closed duplicate, stale, race, rollback, trigger, BLOB, and replay-integrity observations. It is a local proving capsule only. It does not create a Worker, route, provider resource, remote database, production authority, or second tutor domain model. Lifecycle remains `Building` until the frozen/open one-to-one PR gate.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| Stable ID | `0017` |
+| Status | `accepted` — product-lead accepted the intent on 2026-08-11 and reviewed this lifecycle/evidence revision. The implementation and local deterministic proof are complete on the canonical line; no provider, remote, production, or operator authority is granted. |
+| Lifecycle | `Building` — canonical implementation and local evidence are complete, but no frozen/open one-to-one implementation PR exists; **not `Experienceable`, not `Conforming`, not `Release-ready`, and not `Operating`** |
+| Base checkpoint | `a8dafe618907dfd623718802fdaf5712d55f70d4` |
+| Base parent | `33c37975a9eef8628a3b88ae1cbcf2230755234f` |
+| Authoring branch | `spec/0017-tutor-d1-event-store-proof` |
+| Authoring worktree | `/tmp/mono-web-tutor-d1-spec-0017-20260811` |
+| Accepted persistence authority | `/srv/share/projects/vektorprogrammet/docs/decisions/0002-tutor-event-log-persistence.md`; SHA-256 `94a2dbe93d353ddf98af784d3d6a66903c69631f8adc656c07f98a329491c830` |
+| Accepted predecessor | 0014 accepted tracer specification and implementation at integration commit `a8dafe618907dfd623718802fdaf5712d55f70d4` |
+| Independent specification review | `agent://TutorD1ProofSpecReview0017` — PASS at reviewed spec HEAD `988ed2a0600046167e9b7a6e01a6768f714c446a` |
+| Product-lead acceptance | Accepted 2026-08-11 for the intent and this docs-only lifecycle/evidence revision. The product lead remains read-only to implementation and grants no external authority. |
+| Implementation source candidate | `7ddca9eb18c307f7c6baf47134793eda5c299db6` (parent `d04f237b3f3ec6adb0200fca874773976460d477`) under `TutorD1ProofImpl0017`; this candidate is provenance, not the canonical authority. |
+| Canonical D1 integration | `9a166a327a21924537a3a3ac23ede88619b64c98` (parent `e214c872841a90279e6525354ebe1f50232105fa`); canonical implementation paths are integrated and reviewed. |
+| Canonical final head | `ab95b5d36f515d1b60945b9d77a17a7519281493` (parent `beff9154e8efb94c641b6cd6f8d65384ae0110f8`); `beff915` is the canonical provenance repair. |
+| Implementation review | PASS — `agent://TutorD1AcceptanceCode0017` at the source candidate and `agent://CanonicalRepairCodeReview1718` at canonical `ab95b5d36f515d1b60945b9d77a17a7519281493`. The prior BLOCKED review of `4c79fbae8a6d734e44443b1d5a1f7115b4a5ff84` is superseded historical evidence. |
+| Local deterministic evidence | PASS — `agent://CanonicalRepairRuntime1718` at canonical `ab95b5d36f515d1b60945b9d77a17a7519281493`; 23 cases, 110896 evidence bytes, SHA-256 `81d2a752d34c01e6a09e5e0f54c2d56d528a45b51551087583fb07ffa2456985`, repeated digest identical. `agent://TutorD1AcceptanceRuntime0017` recorded superseded source-candidate evidence: 23 cases, 110684 bytes, SHA-256 `e5899fb8ff687f3108c3d2211af997ddb2cc2ce80c7ebe37b58ce76649c4a909`. |
+| Evidence destination | Sanitized evidence is recorded by the named runtime agents and remains destined for the Evidence section of a future frozen one-to-one PR or approved handoff; no generated evidence file is committed. |
+| Current claim | Implementation and local deterministic evidence are complete and integrated at the named canonical commits. All linked blocking Drift is closed. This spec remains `Building` because no frozen/open one-to-one PR exists; it makes no `Experienceable`, `Conforming`, `Release-ready`, `Operating`, provider, remote, production, route, or operator claim. |
+
+This file is the only artifact changed by this docs-only lifecycle/evidence revision. The implementation and runtime evidence named above already exist on the canonical line. No new implementation, package, lock, test, build, install, formatter, linter, provider, remote, data, credential, or deployment action is part of this revision.
+The authoring worktree must remain clean after the spec-only commit. This revision records implementation provenance and independently observed local evidence; it does not grant implementation, provider, remote, production, or operator authority.
+
+## 1. Authority, decision boundary, and semantic inventory
+
+### 1.1 One normative home per fact
+
+This spec routes facts to their authorities. It does not amend them or grant authority that they do not grant.
+
+| Concern | Authority | Use and boundary in this spec |
+|---|---|---|
+| Program order, Receipt-first order, per-context persistence, and operator boundary | [`docs/product-lead-charter.md`](../../docs/product-lead-charter.md), especially §§2–5 and 7–10; durable locator `/srv/share/projects/vektorprogrammet/docs/product-lead-charter.md` | Keeps this persistence proof separate from Worker replacement and keeps Receipt first. The charter grants no external capability. |
+| Lifecycle state, capsule, evidence, and `Drift` | [`docs/agentic-development-lifecycle.md`](../../docs/agentic-development-lifecycle.md), especially §§2 and 4–12; durable locator `/srv/share/projects/vektorprogrammet/docs/agentic-development-lifecycle.md` | This spec is `Building` with implementation and local deterministic evidence complete at canonical `ab95b5d36f515d1b60945b9d77a17a7519281493`. All linked blocking Drift is closed. `Experienceable` and `Conforming` remain unavailable until a frozen/open one-to-one PR and its lifecycle gates exist. |
+| Domain terms and laws | [`docs/domain-model.md`](../../docs/domain-model.md), §§1.3–1.5 and 2.1–2.2; durable locator `/srv/share/projects/vektorprogrammet/docs/domain-model.md` | Keeps `Person`, `Cycle = Department × Semester`, tutor events, `T-INT-1`, `S-INT-1`, `T-INT-2`, and `R-APP-1` in the existing domain model. This spec does not add a state machine or law. |
+| Persistence decision | Accepted ADR 0002 at the exact SHA-256 in Metadata | Defines the three tables, global command ledger, stream-scoped event identity, CAS batch, replay checks, BLOB rules, remote boundary, and §9 successor cases. |
+| Event envelope and pure transition contract | `design-specs/0014-tutor-event-envelope-tracer.md` and `packages/domain/src/tutor/**` at base commit `a8dafe618907dfd623718802fdaf5712d55f70d4` | Defines the closed command/event schemas, exact fixture, duplicate precedence, fold, projection, descriptor, and deterministic evidence. The D1 adapter persists these values; it does not redefine them. |
+| Effect API capability | Local `/srv/share/projects/effect` source, exact beta.107 facts in §5.2 | Source inspection, not memory or a web snippet, is the API authority. The direct D1 path is `D1Client.batch`; generic transaction/journal/migrator paths are forbidden. |
+| Miniflare behavior | Future local proof observation and its pinned package source/lock entry | A local observation proves only the named local binding behavior. It cannot establish remote D1, provider, production, route, or operator facts. |
+| Operator authority | Operator approval and action record described by the lifecycle | None is requested or granted. No external action is allowed by this spec. |
+
+The accepted ADR remains the architecture decision. This live spec is the one-journey successor that can later be accepted as a bounded implementation capsule. A link or source hash is provenance, not a second authority.
+
+### 1.2 Semantic inventory
+
+The proof must keep these meanings distinct:
+
+| Value or operation | Semantic role | Required handling |
+|---|---|---|
+| Unknown `ConductInterview` input | External representation/assertion | Decode with the closed accepted 0014 schema and reject excess or malformed fields. Never cast, default, or silently drop. |
+| `command_id` | One global tutor-context idempotency identity | Read `command_receipts` by this key alone before stream, version, terminal, or transition checks. Its generation format remains open; this proof uses the accepted synthetic value. |
+| `(person_id, department_id, semester_year, semester_term)` | Exact `(Person, Cycle)` stream identity | Use the four columns everywhere. Do not introduce a `stream_id` surrogate or a department/semester substitute. |
+| `event_id` | 0014 stream-scoped event identity | Keep the composite stream key. Do not claim or invent a global event-ID scheme. |
+| `stream_version` | In-stream order authority | Require `1, 2, 3, ...` with no gap, rewind, or duplicate. |
+| `envelope_bytes` | Canonical persisted event fact | Decode and re-encode exactly before fold; indexed columns must agree with the envelope. |
+| `stream_heads` | Mutable CAS/order gate | Check against the folded event log. A mismatch is integrity `Drift`; `ConductInterview` never repairs it. |
+| `command_receipts` | Immutable prior accepted observation | It supports idempotency and exact duplicate response. It is not domain state and never owns projection/status. |
+| Pure 0014 fold | Sole projection/state owner | Fold decoded events; derive the 0014 projection and evidence from the fold. The database has no status or projection table. |
+| Descriptor | Inert post-commit observation | Compute its bytes before the batch, keep it private, and expose it only after the batch commits. Never interpret or deliver it. |
+| Evidence | Deterministic derived artifact | Render canonical UTF-8 bytes and SHA-256 twice from two clean identical local runs. It is a reproducibility receipt, not proof beyond its named scope. |
+
+The event log is canonical fact. The fold is warranted derived state. Reads, receipts, and evidence are projections or observations with references back to the event transition; none becomes a second domain model.
+
+## 2. Goal, values, constraints, and non-goals
+
+### 2.1 Goal
+
+Give one future maintainer one executable, deterministic, local journey that:
+
+1. starts from the accepted 0014 synthetic stream and exact version-three head token;
+2. applies one D1 schema migration without explicit transaction delimiters;
+3. seeds the three accepted 0014 events and their version-three head as fixture setup, outside `ConductInterview`;
+4. decodes and accepts the exact 0014 `ConductInterviewV1` command as `InterviewConducted` version 4 through one direct `D1Client.batch`;
+5. reads the global command ledger before stream validation and classifies exact and changed duplicates correctly;
+6. replays the four persisted envelopes through the pure accepted 0014 fold and compares the projection with the in-memory result;
+7. demonstrates malformed, missing-head, head/event divergence, stale, terminal, same-version race, multi-advance race, foreign-key/unique rollback, trigger, BLOB, decoder, gap, correlation, and index-consistency failures; and
+8. renders two byte-identical evidence documents with equal SHA-256 digests, including the exact local limits and no-provider boundary.
+
+The journey must never accept a fifth event. `InterviewConducted` is terminal under 0014. Replay-only setup may load four canonical rows, but it must not claim a fifth lawful append.
+
+### 2.2 Values
+
+- **Accepted semantics first:** reuse 0014 schemas, event names, command identity, fold, projection, descriptor, and canonicalization. Storage is an adapter, not a new domain model.
+- **One authority per meaning:** event rows own facts; the pure fold owns status/derived state; the global ledger owns idempotent prior observations; the head is an order gate checked against the log.
+- **Fail closed:** malformed input, missing head, terminal transition, stale token, duplicate conflict, unknown decoder, BLOB mismatch, row/index mismatch, gap, correlation mismatch, trigger bypass, SQL surprise, or provider boundary breach stops the proof or returns the accepted typed result. It never guesses or repairs.
+- **Atomic append:** the head update, event insert, and receipt insert are one D1 batch. A failed statement leaves no partial append from that batch.
+- **Deterministic evidence:** no current clock, random source, ambient environment, network, credential, production row, PII, absolute path, or unbounded error text enters the evidence.
+- **Disposable and reversible:** local Miniflare state is the only mutable runtime state. A failed proof deletes or discards that state and records the failure in the future PR/handoff. No remote restore or route rollback is needed.
+
+### 2.3 Constraints
+
+- The only semantic stream is `(PersonId, Cycle)` where `Cycle = Department × Semester`.
+- The accepted 0014 sequence remains `ApplicationReceived → InterviewInvited → InterviewAccepted → InterviewConducted(scores)`.
+- `ApplicationReceived` and version-zero head creation are not part of `ConductInterview`; the proof seeds the version-three state explicitly.
+- `command_id` is globally unique within the tutor context. `event_id` remains stream-scoped. No global event-ID decision is made.
+- Duplicate lookup is global and primary: compare canonical command bytes, not only the SHA-256 index aid.
+- All append statements use numbered SQLite placeholders `?NNN`, bind arrays in the exact ADR order, and map batch result indexes `0`, `1`, and `2` without reordering.
+- BLOB values are actual bytes. The adapter binds `ArrayBuffer`/`ArrayBufferView`, normalizes returned `number[]` to `Uint8Array`, rejects other runtime types, and applies fatal UTF-8 decode plus exact re-encode.
+- The adapter uses `D1Client.batch` directly. It does not call `SqlClient.withTransaction`, `SqlEventJournal`, or generic `Migrator` on this beta.107 D1 path.
+- Migration/import SQL omits `BEGIN TRANSACTION` and `COMMIT`; D1 implicit handling is the only permitted transaction boundary for this proof.
+- Miniflare is local and disposable. No `wrangler --remote`, Alchemy, Cloudflare API, remote binding, credential, Hyperdrive, Durable Object, Worker route, production database, production data, public preview, or deployment is permitted.
+
+### 2.4 Non-goals
+
+This spec does not:
+
+- implement or modify the D1 adapter, migration, local harness, package, lockfile, or any production source;
+- create a D1 database, Worker, route, binding, migration table, remote resource, provider plan, deployment, credential, or operator action;
+- replace Symfony/MySQL before an explicit future authority transition or create a dual-write phase;
+- define stream creation, `ApplicationReceived`, version-zero head creation, global event-ID generation, global command-ID generation format, retention, archival, deletion, legal data obligations, backfill, quarantine, export/import, Time Travel, session bookmarks, remote replica consistency, or cutover;
+- add a status table, projection table, receipt-derived state machine, generic event journal, outbox, effect ledger, queue, retry policy, or external descriptor interpreter;
+- broaden the four-event 0014 trace to all tutor outcomes or all event types; or
+- use a deployment log, code review, package install, local process banner, or narrative as event-store, domain, provider, production, route, or operator proof.
+
+## 3. Accepted 0014 contract and exact synthetic fixture
+
+### 3.1 Stream and event contract
+
+The stream key is exactly:
+
+```text
+Stream = (PersonId, Cycle)
+Cycle  = Department × Semester
+```
+
+Persist it as:
+
+```text
+(person_id, department_id, semester_year, semester_term)
+```
+
+The accepted event names and sequence are:
+
+```text
+v1 ApplicationReceived
+v2 InterviewInvited
+v3 InterviewAccepted
+v4 InterviewConducted(scores)
+```
+
+`status` is a pure fold projection. It is never an event field and never a table. The only laws exercised are the accepted 0014 bounded laws: `T-INT-1`, `S-INT-1`, `T-INT-2`, and `R-APP-1`. Wider tutor events and outcomes remain successors.
+
+### 3.2 Fixed fixture values
+
+All values are UTF-8, synthetic, PII-free, and fixed. The future proof must not substitute current time, random IDs, generated UUIDs, environment values, or production values.
+
+| Name | Exact value |
+|---|---|
+| `fixtureId` | `tutor-event-envelope-0014` |
+| `personId` | `person-synth-0014` |
+| `departmentId` | `department-synth-0014` |
+| `semester` | `{ year: 2026, term: "Vår" }` |
+| `correlationId` | `corr-0014-tutor` |
+| `seed event 1` | `evt-0014-001`, `streamVersion=1`, `ApplicationReceived`, `occurredAt=2026-08-11T09:00:00Z`, `causationId=tutor-event-envelope-0014` |
+| `seed event 2` | `evt-0014-002`, `streamVersion=2`, `InterviewInvited`, `occurredAt=2026-08-11T09:01:00Z`, `causationId=tutor-event-envelope-0014` |
+| `seed event 3` | `evt-0014-003`, `streamVersion=3`, `InterviewAccepted`, `occurredAt=2026-08-11T09:02:00Z`, `causationId=tutor-event-envelope-0014` |
+| `seed head` | exact stream tuple, `current_version=3`, `last_command_id=tutor-event-envelope-0014` |
+| `accepted commandId` | `cmd-0014-conduct` |
+| `accepted expectedVersion` | `3` |
+| `accepted scores` | `(explanatoryPower=8, roleModel=9, suitability=7, suitableAssistant="Ja")` |
+| `accepted answers` | `{ "q-0014-a": "answer-a", "q-0014-b": "answer-b" }` |
+| `accepted eventId` | `evt-0014-004` |
+| `accepted event type` | `InterviewConducted` |
+| `accepted event version` | `4` |
+| `accepted occurredAt/conductedAt` | `2026-08-11T09:03:00Z` |
+| `accepted event causationId` | `cmd-0014-conduct` |
+| `accepted event correlationId` | `corr-0014-tutor` |
+| `malformed commandId` | `cmd-0014-malformed` |
+| `stale commandId` | `cmd-0014-stale` |
+| `terminal commandId` | `cmd-0014-terminal` |
+| `other-stream personId` | `person-synth-0014-other` |
+| `missing-head personId` | `person-synth-0017-missing-head` |
+| `race command IDs` | `cmd-0017-race-a`, `cmd-0017-race-b` |
+| `multi-advance command IDs` | `cmd-0017-advance-a`, `cmd-0017-advance-b` |
+
+The first three `causationId` values are the fixture ID, so the exact seed head token is `tutor-event-envelope-0014`, not the accepted command ID. For every non-empty valid stream, the head token must equal the last event `causation_id`; this is the ADR invariant.
+
+The exact accepted command, after closed-schema decode and canonical JSON sorting, is semantically:
+
+```json
+{
+  "schemaVersion": 1,
+  "commandId": "cmd-0014-conduct",
+  "correlationId": "corr-0014-tutor",
+  "stream": {
+    "personId": "person-synth-0014",
+    "cycle": {
+      "departmentId": "department-synth-0014",
+      "semester": { "year": 2026, "term": "Vår" }
+    }
+  },
+  "expectedVersion": 3,
+  "scores": {
+    "explanatoryPower": 8,
+    "roleModel": 9,
+    "suitability": 7,
+    "suitableAssistant": "Ja",
+    "answers": { "q-0014-a": "answer-a", "q-0014-b": "answer-b" }
+  }
+}
+```
+
+Canonical command bytes are produced after decode by the accepted 0014 canonicalizer. The implementation compares complete bytes in `command_receipts.command_bytes`; `command_sha256` is an index aid and is not sufficient for duplicate equality.
+
+### 3.3 Accepted result and descriptor
+
+The accepted append produces only version 4 and the accepted 0014 projection:
+
+```text
+projectionVersion = 1
+streamVersion     = 4
+status            = completed
+eventTypes        = [ApplicationReceived, InterviewInvited,
+                     InterviewAccepted, InterviewConducted]
+conductedAt       = 2026-08-11T09:03:00Z
+lawRefs           = [T-INT-1, S-INT-1, T-INT-2, R-APP-1]
+```
+
+The inert descriptor is exactly the accepted 0014 shape:
+
+```json
+{
+  "descriptorVersion": 1,
+  "kind": "InterviewConductedDescriptor",
+  "sourceEventId": "evt-0014-004",
+  "causationId": "cmd-0014-conduct",
+  "correlationId": "corr-0014-tutor",
+  "idempotencyKey": "post-commit:evt-0014-004"
+}
+```
+
+It has no destination, recipient, body, transport, provider, retry, queue, interpreter, or execution. A duplicate returns the stored descriptor as an observation; it does not create another effect request.
+
+## 4. D1 schema migration
+
+### 4.1 Migration identity and application
+
+The future implementation capsule names this migration file:
+
+```text
+packages/domain/src/tutor/migrations/0001-tutor-event-store.sql
+```
+
+The stable migration ID is `0017-0001-tutor-event-store`. The exact UTF-8 SQL bytes, in the committed file order, are hashed in future evidence as `schemaHash`. The migration is applied once to the disposable local D1 binding, in the order shown below, without `BEGIN TRANSACTION` or `COMMIT`. The future writer must use the local binding operation actually exposed by the selected Miniflare version and record that operation; if it is not source-verified, stop in `Drift` rather than inventing a helper.
+
+The following SQL is the required ADR 0002 schema. Equivalent SQLite syntax is acceptable only when the future proof establishes the same tables, type checks, primary keys, unique keys, foreign keys, trigger messages, and row behavior.
+
+```sql
+CREATE TABLE stream_heads (
+  person_id TEXT NOT NULL,
+  department_id TEXT NOT NULL,
+  semester_year INTEGER NOT NULL,
+  semester_term TEXT NOT NULL CHECK (semester_term IN ('Vår', 'Høst')),
+  current_version INTEGER NOT NULL CHECK (current_version >= 0),
+  last_command_id TEXT,
+  PRIMARY KEY (person_id, department_id, semester_year, semester_term),
+  CHECK (
+    (current_version = 0 AND last_command_id IS NULL)
+    OR (current_version > 0 AND last_command_id IS NOT NULL)
+  )
+) STRICT;
+
+CREATE TABLE tutor_events (
+  person_id TEXT NOT NULL,
+  department_id TEXT NOT NULL,
+  semester_year INTEGER NOT NULL,
+  semester_term TEXT NOT NULL CHECK (semester_term IN ('Vår', 'Høst')),
+  event_id TEXT NOT NULL,
+  stream_version INTEGER NOT NULL CHECK (stream_version > 0),
+  schema_version INTEGER NOT NULL CHECK (schema_version > 0),
+  event_type TEXT NOT NULL,
+  envelope_bytes BLOB NOT NULL CHECK (typeof(envelope_bytes) = 'blob'),
+  occurred_at TEXT NOT NULL,
+  causation_id TEXT NOT NULL,
+  correlation_id TEXT NOT NULL,
+  PRIMARY KEY (person_id, department_id, semester_year, semester_term, event_id),
+  UNIQUE (person_id, department_id, semester_year, semester_term, stream_version),
+  UNIQUE (
+    person_id,
+    department_id,
+    semester_year,
+    semester_term,
+    event_id,
+    stream_version,
+    causation_id
+  ),
+  FOREIGN KEY (person_id, department_id, semester_year, semester_term)
+    REFERENCES stream_heads (person_id, department_id, semester_year, semester_term)
+) STRICT;
+
+CREATE TABLE command_receipts (
+  person_id TEXT NOT NULL,
+  department_id TEXT NOT NULL,
+  semester_year INTEGER NOT NULL,
+  semester_term TEXT NOT NULL CHECK (semester_term IN ('Vår', 'Høst')),
+  command_id TEXT NOT NULL,
+  command_bytes BLOB NOT NULL CHECK (typeof(command_bytes) = 'blob'),
+  command_sha256 TEXT NOT NULL,
+  result_bytes BLOB NOT NULL CHECK (typeof(result_bytes) = 'blob'),
+  descriptor_bytes BLOB NOT NULL CHECK (typeof(descriptor_bytes) = 'blob'),
+  event_id TEXT NOT NULL,
+  event_stream_version INTEGER NOT NULL CHECK (event_stream_version > 0),
+  PRIMARY KEY (command_id),
+  FOREIGN KEY (
+    person_id,
+    department_id,
+    semester_year,
+    semester_term,
+    event_id,
+    event_stream_version,
+    command_id
+  ) REFERENCES tutor_events (
+    person_id,
+    department_id,
+    semester_year,
+    semester_term,
+    event_id,
+    stream_version,
+    causation_id
+  )
+) STRICT;
+
+CREATE TRIGGER tutor_events_immutable_update
+BEFORE UPDATE ON tutor_events
+BEGIN
+  SELECT RAISE(ABORT, 'tutor_events are immutable');
+END;
+
+CREATE TRIGGER tutor_events_immutable_delete
+BEFORE DELETE ON tutor_events
+BEGIN
+  SELECT RAISE(ABORT, 'tutor_events are immutable');
+END;
+
+CREATE TRIGGER command_receipts_immutable_update
+BEFORE UPDATE ON command_receipts
+BEGIN
+  SELECT RAISE(ABORT, 'command_receipts are immutable');
+END;
+
+CREATE TRIGGER command_receipts_immutable_delete
+BEFORE DELETE ON command_receipts
+BEGIN
+  SELECT RAISE(ABORT, 'command_receipts are immutable');
+END;
+```
+
+The schema deliberately has no status table, projection table, `stream_id` surrogate, global event-ID key, command status row, outbox, or effect ledger. `stream_heads` is mutable only through the CAS append and remains subject to the folded log checks. `tutor_events` and `command_receipts` are immutable after insertion. A head cannot be deleted while event rows reference it.
+
+### 4.2 Constraint meanings
+
+- `stream_heads` is the sole mutable order gate. Version zero requires a null token; every non-empty head requires a token.
+- `tutor_events` keeps explicit stream columns, stream-scoped `event_id`, positive `stream_version`, positive `schema_version`, the event type, canonical complete envelope bytes, occurrence time, causation, and correlation.
+- The event primary key is `(stream, event_id)`. The event unique version key is `(stream, stream_version)`. The third unique key prevents the same stream/event/version/causation tuple from being silently duplicated.
+- `command_receipts.command_id` is the global tutor-context primary key. Its composite foreign key includes the command ID and points to `tutor_events.causation_id`; therefore a stale batch cannot attach a receipt to an older event that merely shares stream, event ID, and version.
+- The event and receipt byte columns require SQLite `BLOB` storage. The adapter still validates runtime values and exact bytes; SQLite type checks alone are not a complete adapter proof.
+- `envelope_bytes` is the canonical complete envelope. Separate indexed columns are query aids and must match the decoded envelope during replay.
+- `result_bytes` is the canonical accepted observation and `descriptor_bytes` is the inert descriptor observation. Neither is domain state.
+
+## 5. Adapter boundary and exact Effect beta.107 use
+
+### 5.1 Owned adapter operations
+
+The future capsule may expose a narrow tutor event-store service with these operations. Names are implementation detail; their semantics are not.
+
+| Operation | Required behavior | Authority |
+|---|---|---|
+| `readStream(stream)` | Read the primary event rows in ascending `stream_version`, normalize/verify BLOBs, decode envelopes, and invoke the pure 0014 fold. Never derive status from SQL columns alone. | D1 event rows plus accepted fold |
+| `findReceipt(commandId)` | Read `command_receipts` by global `command_id` alone from the primary. Return canonical command/result/descriptor bytes for comparison. | Global command ledger |
+| `appendAccepted(command)` | Decode command, perform global ledger read, read head/events from primary, fold and validate, compute event/result/descriptor bytes, run exactly the three-statement batch, classify failure by a second primary ledger read, then expose observation only after commit. | Adapter plus D1 batch; domain meaning remains 0014 |
+
+A local single D1 binding is treated as the primary for this proof. No replica, session bookmark, read cache, or read-after-write inference is used. The proof records this as a local limitation, not as remote consistency evidence.
+
+### 5.2 Exact local Effect API facts
+
+The future writer must re-open the local source before implementation. The observed source facts are:
+
+- `/srv/share/projects/effect/packages/sql/d1/package.json` declares `@effect/sql-d1` version `4.0.0-beta.107`; file SHA-256 `e4e2ccecc5a7e11dd08892cd5cf7a15568a27767a51e2b7ff688e8444b98236a`.
+- `/srv/share/projects/effect/packages/sql/d1/src/D1Client.ts` SHA-256 is `33d086b2b5599349e012f93241d40f079ff78d09ddea00857744217e39b8647e`.
+- In that source, `D1Client.batch` is a service method returning a tuple of statement-success arrays in input order (lines 58–89). Its implementation compiles/binds each statement, calls the D1 binding's `db.batch(prepared)` directly, checks each response error, maps each response's `results || []`, and preserves index order (lines 130–188).
+- The same source sets the D1 transaction acquirer to `Effect.die("transactions are not supported in D1")` (lines 315–327). Its `layer` constructor provides both `D1Client` and `SqlClient` (lines 388–402), but this proof uses the D1-specific batch method, not a generic SQL transaction.
+- `/srv/share/projects/effect/packages/effect/src/unstable/sql/Statement.ts` SHA-256 is `d0217382c9cded3a4f143058461b96aecf18c0f2daedd7995e726831d7cc12f5`; the future writer must verify the beta.107 statement construction used to preserve literal numbered placeholders and bind order.
+- `/srv/share/projects/effect/packages/effect/src/unstable/eventlog/SqlEventJournal.ts` SHA-256 is `e7912dad2892ce246a1143389d17b9d8277df2eb204b92c4e3808437c1d0b9a8`. Its generic schema/IDs/conflict behavior/transaction path do not implement this contract and are forbidden here.
+- `/srv/share/projects/effect/packages/effect/src/unstable/sql/Migrator.ts` SHA-256 is `c94e7d36a4d253210e76e694bde656aeace439e541e503b9442e06bf95878de9`; its generic migration table and `SqlClient.withTransaction` path are forbidden here.
+- `/srv/share/projects/effect/packages/effect/src/unstable/sql/SqlClient.ts` SHA-256 is `ec65f43418586cdf41c6389420da8f5b05000e88a017ddb4d77627e2b8b0ebfc`; its generic transaction surface is not a D1 capability.
+
+These are source facts for beta.107 only. A later Effect version requires a new source review and a spec revision or explicit `Drift`; no API is inferred from a package name or remembered v3 example.
+
+### 5.3 Strict BLOB adapter
+
+The adapter must make the representation boundary observable and fail closed:
+
+1. Encode canonical command, envelope, result, and descriptor JSON as UTF-8 bytes. Bind each byte value as an `ArrayBuffer` or `ArrayBufferView` accepted by the selected beta.107 statement path. Do not bind a JSON string, object, numeric array, or hash in place of bytes.
+2. For a returned BLOB, accept a runtime byte representation only when the local binding actually returns one of the source-verified forms. Normalize a `number[]` whose entries are integers in `0..255` to `Uint8Array`. Normalize a returned `ArrayBuffer`/`ArrayBufferView` to a byte view without changing bytes. Reject strings, objects, arbitrary arrays, null, and any other runtime type with a typed integrity failure.
+3. Decode persisted bytes with a fatal UTF-8 decoder. Re-encode the decoded value with UTF-8 and compare length and every byte to the original. A decoding error or byte mismatch is integrity `Drift`; do not fold, compare command content, or expose a receipt.
+4. Compare complete canonical `command_bytes` before using `command_sha256`. A matching digest with different bytes is not an exact duplicate. A different digest is a conflict, but the implementation still preserves the complete-byte comparison evidence.
+5. Verify SQLite `typeof(...) = 'blob'` for all four BLOB columns in schema/fault scenarios. A value that reaches the adapter as a string or object fails even if the database query can otherwise return it.
+
+The proof must not silently rely on Bun `Buffer` coercion, JSON replacement characters, permissive UTF-8 decoding, or a transitive result transformer. Any source/API mismatch enters `Drift`.
+
+## 6. Append protocol, primary reads, and batch order
+
+### 6.1 Decode and global primary-ledger lookup
+
+1. Decode unknown input with the closed 0014 `ConductInterviewV1` schema and excess-property error mode. Compute canonical command bytes only after decode. A malformed or excess-field command returns `DecodeError` and performs no database write.
+2. Read the command ledger from the D1 primary by global command ID before reading the stream head, folding events, testing `expectedVersion`, or testing terminal state:
+
+```sql
+SELECT command_id, command_bytes, result_bytes, descriptor_bytes
+FROM command_receipts
+WHERE command_id = ?1;
+```
+
+The bind order is exactly `[commandId]`.
+
+3. If a receipt exists and the complete stored `command_bytes` equal the decoded canonical bytes, return the stored observation and descriptor as an exact duplicate. This result wins even when the stream is now terminal or stale.
+4. If a receipt exists and bytes differ, return `DuplicateCommandConflict` before stream validation, including when the changed command names another stream. The global command ID cannot be reused across streams.
+5. Only an unseen command ID proceeds to head/event reads and pure validation.
+
+### 6.2 Head, event read, and pure validation
+
+Read the head from the primary with stream bind order `[personId, departmentId, semesterYear, semesterTerm]`. Read events with the exact replay query in §7. The head and event log must satisfy all of these before the batch:
+
+- the head exists; otherwise return `EMPTY_STREAM` and write no row;
+- the event rows all have the requested stream tuple;
+- versions are contiguous from `1`, with no gap, duplicate, rewind, or terminal fifth event;
+- event IDs are unique within the stream;
+- `occurred_at` never moves backward;
+- all envelopes have the accepted correlation ID and the command correlation matches the folded correlation;
+- head `current_version` equals folded event count;
+- for a non-empty stream, head `last_command_id` equals the last event `causation_id`;
+- a version-zero head, if encountered in a future explicit stream setup, has a null token;
+- `expectedVersion` equals the folded current version; and
+- the transition is lawful under 0014 (`ConductInterview` only from `Accepted`, and `Conducted` is terminal).
+
+A head/event mismatch is a typed integrity failure and lifecycle `Drift`. The append path never repairs the head or event log. A missing head is `EMPTY_STREAM`, not implicit stream creation. `ApplicationReceived` and version-zero creation remain a separate successor.
+
+The adapter sets `expectedLastCommandId` to the last event `causation_id` and `newVersion = expectedVersion + 1`. It computes the v4 event, pure-fold projection, accepted observation, canonical result bytes, descriptor bytes, and receipt bytes before entering the batch. It keeps descriptor/result observations private until the batch commits. It reads no clock or random source.
+
+### 6.3 Exact three-statement D1 batch
+
+The future writer must preserve this SQL and placeholder numbering. Do not concatenate values into SQL. Do not replace `?NNN` with named placeholders.
+
+```sql
+-- Result index 0: compare and set the stream head and CAS token.
+UPDATE stream_heads
+SET current_version = current_version + 1,
+    last_command_id = ?7
+WHERE person_id = ?1
+  AND department_id = ?2
+  AND semester_year = ?3
+  AND semester_term = ?4
+  AND current_version = ?5
+  AND last_command_id IS ?6
+RETURNING current_version, last_command_id;
+
+-- Result index 1: insert the event only when the new head and token exist.
+INSERT INTO tutor_events (
+  person_id,
+  department_id,
+  semester_year,
+  semester_term,
+  event_id,
+  stream_version,
+  schema_version,
+  event_type,
+  envelope_bytes,
+  occurred_at,
+  causation_id,
+  correlation_id
+)
+SELECT
+  h.person_id,
+  h.department_id,
+  h.semester_year,
+  h.semester_term,
+  ?7,
+  h.current_version,
+  ?8,
+  ?9,
+  ?10,
+  ?11,
+  ?6,
+  ?12
+FROM stream_heads AS h
+WHERE h.person_id = ?1
+  AND h.department_id = ?2
+  AND h.semester_year = ?3
+  AND h.semester_term = ?4
+  AND h.current_version = ?5
+  AND h.last_command_id = ?6;
+
+-- Result index 2: the FK requires the exact event and command causation.
+INSERT INTO command_receipts (
+  person_id,
+  department_id,
+  semester_year,
+  semester_term,
+  command_id,
+  command_bytes,
+  command_sha256,
+  result_bytes,
+  descriptor_bytes,
+  event_id,
+  event_stream_version
+)
+VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11);
+```
+
+The bind arrays are part of the contract:
+
+```text
+Statement 0 / head CAS:
+[personId, departmentId, semesterYear, semesterTerm,
+ expectedVersion, expectedLastCommandId, commandId]
+
+Statement 1 / event INSERT...SELECT:
+[personId, departmentId, semesterYear, semesterTerm,
+ newVersion, commandId, eventId, schemaVersion, eventType,
+ envelopeBytes, occurredAt, correlationId]
+
+Statement 2 / receipt insert:
+[personId, departmentId, semesterYear, semesterTerm,
+ commandId, commandBytes, commandSha256, resultBytes,
+ descriptorBytes, eventId, newVersion]
+```
+
+The adapter maps the returned tuple by position:
+
+```text
+batch result 0 → head UPDATE ... RETURNING
+batch result 1 → event INSERT ... SELECT
+batch result 2 → command_receipts INSERT
+```
+
+It requires result `0` to contain exactly one row with `(current_version, last_command_id) = (newVersion, commandId)`. A stale version or token returns zero rows at result `0`; result `1` then inserts no event and result `2` fails the composite event-causation foreign key, so the D1 batch must roll back. The future proof records the actual local result arrays and does not infer affected-row counts from an `INSERT` result that has no `RETURNING`; it proves row existence and count with subsequent primary reads.
+
+If another writer wins the same version, result `0` is stale. If a fixture race advances the head beyond `newVersion`, result `1` cannot select the required head and result `2` cannot satisfy its FK. If an older event has the same stream/event ID/version but a different causation ID, the receipt FK cannot attach to it. A duplicate global receipt, duplicate stream event ID, or duplicate stream version is a real constraint failure, never success. D1 must roll back the head and all earlier statements in this batch.
+
+### 6.4 Failed-batch classification
+
+After any batch error, do not retry the write first. Read the global command ledger again by `command_id` from the primary:
+
+1. Receipt exists with identical command bytes → return the stored duplicate observation.
+2. Receipt exists with different command bytes → return `DuplicateCommandConflict`, even if the competing receipt names another stream.
+3. No receipt → read the stream head from the primary.
+4. Head missing → return `EMPTY_STREAM`.
+5. Head version or last-command token differs from preflight → return `StaleState`.
+6. Head still matches, no receipt exists, and SQL/constraint failure remains → surface the typed failure and enter `Drift`; never hide it as stale or success.
+
+Evidence for every failed batch records the command-ledger read, head observation, event count, receipt count, and before/after row counts. A valid race classification may observe a competing writer's rows; the proof separately identifies those rows and demonstrates that the failed batch itself added no head/event/receipt rows.
+
+## 7. Replay and pure-fold ownership
+
+### 7.1 Exact replay query
+
+Replay uses the primary and this query/order:
+
+```sql
+SELECT
+  person_id,
+  department_id,
+  semester_year,
+  semester_term,
+  event_id,
+  stream_version,
+  schema_version,
+  event_type,
+  envelope_bytes,
+  occurred_at,
+  causation_id,
+  correlation_id
+FROM tutor_events
+WHERE person_id = ?1
+  AND department_id = ?2
+  AND semester_year = ?3
+  AND semester_term = ?4
+ORDER BY stream_version ASC;
+```
+
+The bind order is exactly `[personId, departmentId, semesterYear, semesterTerm]`. The adapter verifies every returned row before passing it to `foldEvents`:
+
+- versions are exactly `1, 2, 3, ...`;
+- event IDs are unique in the stream;
+- event stream fields equal the query stream;
+- decoded envelope fields equal every indexed column, including event ID, version, schema version, type, occurrence, causation, and correlation;
+- the event-log correlation rule from 0014 holds; correlation does not come from `stream_heads`;
+- `(event_type, schema_version)` resolves through a versioned decoder registry;
+- historical decoding/upcasting never rewrites the stored row; and
+- unknown event types or schema versions fail closed.
+
+The proof creates each persisted replay bad-row case by inserting one fresh row into a re-seeded local binding; it never mutates or deletes a persisted event. This applies to unknown event type/schema, version gap, `occurred_at` rewind, correlation mismatch, and indexed/envelope mismatch, including a decoded envelope whose stream differs from the indexed stream. The immutable triggers intentionally prevent mutation. Duplicate event ID/version and true cross-stream rows cannot be returned as a queried persisted row under the primary-key/unique constraints and stream query; supply those two cases as adapter row-array/fold-input cases and label that local capability limit in evidence. Every gap, duplicate, rewind, cross-stream, correlation, or index mismatch is not silently skipped.
+
+### 7.2 Pure fold and projection
+
+The future adapter calls the accepted 0014 pure `foldEvents`/`projectFoldedState` logic (or an equivalent source-preserving extraction) after bytes and indexed fields pass validation. It does not implement another fold in SQL, a repository class, a status table, or a read-time status derivation. The projection remains:
+
+```text
+fold(event envelopes) → FoldedState
+FoldedState           → 0014 Projection
+Projection            → canonical evidence
+```
+
+A receipt result is a stored prior observation for idempotency. It is not a projection source. Replay never interprets the descriptor. The event log provides facts, the pure fold provides state, and the evidence renderer provides canonical bytes and digest.
+
+### 7.3 Compute-before/expose-after descriptor boundary
+
+For a new accepted command, the adapter computes before the batch:
+
+1. the v4 event envelope and canonical `envelope_bytes`;
+2. the pure-fold projection and accepted observation;
+3. the inert descriptor and canonical `descriptor_bytes`;
+4. canonical `result_bytes`, `command_bytes`, and `command_sha256`; and
+5. the three statements and exact bind arrays.
+
+It exposes none of the accepted observation or descriptor as an effect request until all three batch statements commit and result `0` is verified. If the batch fails, it returns a typed failure or a classified prior receipt and exposes no newly computed descriptor. A successful exact duplicate returns stored bytes only as an idempotent observation. There is no effect interpreter in this capsule.
+
+## 8. One local Miniflare proof journey
+
+### 8.1 Runtime boundary and reset rule
+
+The future proof runs one disposable local Miniflare D1 binding in one process. A loopback-only harness may be used when a local process boundary is necessary; bind only to `127.0.0.1` and do not expose a Worker route. An in-process binding is preferred. The proof must record the actual Miniflare version and binding setup from its package source/lock.
+
+All cases below use this one disposable binding and deterministic synthetic values. A case that requires an intentionally inconsistent head/event or a race may reset/re-seed the same binding between cases or use a separately named synthetic stream in the same schema. Reset/discard is local state disposal, not a second database authority. No case creates a remote binding, uses production data, or claims a fifth lawful 0014 event.
+
+Before each case that mutates fixture state, record bounded counts for `stream_heads`, `tutor_events`, and `command_receipts`. After the case, record counts and the canonical row identities. For intentional concurrent setup rows, distinguish the setup writer's rows from the candidate batch's rows and discard the entire binding at the end.
+
+### 8.2 ADR §9 cases and required observations
+
+The numbered cases are the accepted ADR §9 successor sequence. The future proof must execute all of them and retain sanitized observations in the eventual PR/handoff.
+
+| ADR §9 case | Local operation | Required fail-closed observation |
+|---:|---|---|
+| 1 | Apply migration `0017-0001-tutor-event-store` once, with no `BEGIN TRANSACTION` or `COMMIT`. | All three `STRICT` tables, required checks/keys/FKs, and four immutable triggers exist. Record migration ID, SQL-byte `schemaHash`, applied order, and actual local binding operation. |
+| 2 | Seed the exact 0014 stream: one head at `current_version=3`, `last_command_id=tutor-event-envelope-0014`, and v1–v3 rows with exact IDs/types/times/causation/correlation. | Seed rows are contiguous and fold to `accepted`; no receipt or descriptor exists. Head token equals v3 causation. |
+| 3 | Treat head and v1–v3 rows as fixture setup. Do not invoke stream creation through `ConductInterview`. | The command path cannot create a missing head or version-zero state. Any attempt is `EMPTY_STREAM` with no write. |
+| 4 | Decode exact command `cmd-0014-conduct`, compute v4 and descriptor privately, and run the three-statement batch. | Exactly one new v4 `InterviewConducted` row and one receipt commit; result index 0 is exactly `(4, cmd-0014-conduct)`; descriptor/observation become visible only after commit; no fifth event or external call. |
+| 5 | Record the four-row persisted fixture. For a replay-only run, load exactly those four canonical rows as fixture data. | Persisted replay and the in-memory 0014 result have the same projection. No replay-only case accepts or invents v5 because `InterviewConducted` is terminal. |
+| 6 | Submit `cmd-0014-malformed` with an excess field or missing answer. | Closed decode returns `DecodeError`; all three table counts and canonical rows remain unchanged. |
+| 7 | Submit a well-formed command for `person-synth-0017-missing-head` (or another fixed stream with no head). | Global ledger miss followed by missing-head classification returns `EMPTY_STREAM`; no head, event, or receipt row is created. |
+| 8 | Prepare a head/event divergence (for example, head version/token disagrees with the folded three rows) and invoke the append. | Adapter returns integrity failure and enters `Drift`; it does not repair the head or event rows and does not expose a descriptor. |
+| 9 | Submit a well-formed command with stale `expectedVersion` or stale last-command token. | `StaleState`; no head, event, or receipt change. Evidence includes the preflight and post-failure head token/version. |
+| 10 | Submit distinct `cmd-0014-terminal` at version 4 against the accepted four-row stream. | `InvalidTransition` with terminal `Conducted` / `T-INT-2`; no row or descriptor change. |
+| 11 | Submit the exact original global ID `cmd-0014-conduct` and byte-identical canonical command again, after the stream is terminal. | Global primary-ledger read returns the stored result/descriptor before terminal validation as `DuplicateResult`; no second event, receipt, or descriptor. |
+| 12 | Submit the same global `command_id` with changed canonical bytes, including a changed stream using `person-synth-0014-other`. | `DuplicateCommandConflict` before stream/version/terminal checks; no state change. It must not be accepted on the other stream. |
+| 13 | Start two real local writers with the same stream and expected version (`cmd-0017-race-a` and `cmd-0017-race-b`). | Exactly one CAS wins and commits at most one event/receipt; the other is `StaleState` (or the prescribed ledger classification) with no partial rows. Row counts prove one accepted append, not two. |
+| 14 | Exercise two multi-advance subcases from a preflight barrier: (a) a concurrent writer leaves an older same-stream/event/version row with a different causation token; (b) a protocol-only fixture writer advances the head beyond the candidate `newVersion` before the stale batch's statement 1/2 path. | The composite command-to-causation FK prevents receipt attachment to the older event; the batch rolls back. The beyond-version case does not create a fifth lawful 0014 event; it is a storage-race/integrity fixture and is discarded. Classify by the second primary ledger read and head token, never as success. |
+| 15 | Force real constraint failures after preflight: a receipt primary-key conflict from a concurrent same-global-ID writer, and an event unique-key conflict from an intentionally injected local fixture row. | D1 rolls back the head update and every earlier statement in each candidate batch. The proof records FK/unique error, before/after head/event/receipt counts, second-ledger classification, and any competing setup rows separately. No uniqueness error becomes success. |
+| 16 | Attempt `UPDATE` and `DELETE` on both `tutor_events` and `command_receipts`. | All four operations abort with exact trigger messages: `tutor_events are immutable` for event update/delete and `command_receipts are immutable` for receipt update/delete. Rows remain byte-identical. |
+| 17 | Make the local binding return BLOB values as `number[]` in the adapter boundary. | Adapter normalizes to `Uint8Array`; fatal UTF-8 decode and exact UTF-8 re-encode preserve every byte; fold/replay succeeds only after the comparison. |
+| 18 | Supply a wrong BLOB runtime type (string, object, null, or invalid array) through a real local result/adapter boundary. | Typed integrity failure and `Drift`; no fold, duplicate equality, descriptor exposure, or state mutation. |
+| 19 | Capture the SQL text, numbered placeholders, bind arrays, and returned tuple for the accepted append and a stale batch. | Every statement uses `?NNN`; bind orders exactly match §6.3; result `0/1/2` maps to head/event/receipt; no named placeholder or reordered result is accepted. |
+| 20 | Replay the persisted stream, then run isolated bad-row subcases. For persisted rows, re-seed and insert one fresh schema-reachable row for unknown `(event_type, schema_version)`, version gap, `occurred_at` rewind, correlation mismatch, or indexed/envelope mismatch (including a decoded envelope whose stream differs from the indexed stream). For duplicate event ID/version and true cross-stream rows, pass adapter row-array/fold-input values; PK/UNIQUE/query behavior makes those unpersistable as queried rows, so record the local limit. | Valid replay folds to the accepted 0014 projection. Every persisted bad row fails closed before projection; adapter duplicate/version and cross-stream cases fail closed at the fold boundary. Unknown decoder/schema is not guessed, and historical rows are never rewritten. |
+| 21 | Render the complete sanitized evidence document twice from two clean identical local runs. | Canonical UTF-8 bytes, trailing newline, and SHA-256 digest are byte-identical. Evidence includes all case tags, counts, replay order, projection, descriptor count, source/version/hash facts, and explicit local/no-provider limits. |
+
+The race and constraint cases are real D1 operations. A controlled barrier or fixture row is not a mock success: it arranges a known interleaving or database constraint and observes the actual local batch result. Any impossible local capability, unknown result shape, or source mismatch is a `Drift`, not a simulated pass.
+
+### 8.3 Required final observations
+
+At the end of the accepted path, the local database contains exactly one canonical stream with four event rows and one accepted receipt for `cmd-0014-conduct` (plus explicitly identified disposable setup rows only while a fault case is active). The replay projection is `completed`, the event list is `[evt-0014-001, evt-0014-002, evt-0014-003, evt-0014-004]`, the stream version is `4`, and the accepted descriptor count is `1`.
+
+The future proof must not claim that these local rows are a live tutor authority. They are a local observation over synthetic data. The local binding is deleted/discarded after evidence capture.
+
+## 9. Deterministic evidence contract
+
+### 9.1 Evidence document
+
+The eventual PR/handoff must contain one sanitized evidence document, not a committed generated evidence file. Its canonical JSON top-level key order is fixed as:
+
+```text
+formatVersion,
+specId,
+baseCommit,
+adrSha256,
+predecessorCommit,
+fixtureId,
+schemaMigrationId,
+schemaHash,
+localEffectVersion,
+localEffectSourceHashes,
+localMiniflareVersion,
+correlationId,
+stream,
+seedHead,
+seedEvents,
+batch,
+cases,
+replay,
+projection,
+effectDescriptors,
+rowCounts,
+limits,
+provenance
+```
+
+Encode as UTF-8 JSON with one trailing newline. Recursively sort object keys inside values while preserving the listed top-level order and semantic array order. Compute `sha256(canonicalBytes)` over the exact bytes. Do not include a generated timestamp, random ID, absolute path, environment dump, raw stack trace, credential, PII, or unbounded SQL/provider error.
+
+The document records:
+
+- spec ID `0017`, base commit `a8dafe618907dfd623718802fdaf5712d55f70d4`, accepted predecessor commit, ADR SHA-256, fixture ID, migration ID, SQL schema hash, and exact source/version/hash facts;
+- the stream tuple, seed head token, seed event IDs/versions, accepted command/event/causation/correlation IDs, and descriptor count;
+- statement SQL fingerprints or canonical SQL bytes, numbered bind order, result indexes, and the verified `(newVersion, commandId)` row;
+- each ADR §9 case, result tag, typed reason, bounded before/after row counts, and whether rows were fixture setup, candidate batch, or competing writer;
+- replay order, decoder/upcaster key, projection, law references, index/envelope checks, and explicit unknown-schema/gap/correlation/mismatch outcomes;
+- two-run canonical byte lengths and equal SHA-256 digest; and
+- local capability limits and forbidden surfaces.
+
+### 9.2 Evidence scope
+
+Evidence proves only the named local Miniflare D1 behavior and the accepted 0014 semantics exercised by the journey. It does not prove remote D1 SQL/result shape, primary/session consistency, replica behavior, D1 limits, migration service behavior, export/import, Time Travel, Hyperdrive, Durable Objects, Worker routing, provider behavior, production data, authorization, deployment, cutover, rollback ownership, or operator authority. A digest is a reproducibility receipt, not domain conformance proof.
+
+## 10. Local Miniflare capability limits and exact no-provider boundary
+
+### 10.1 What the local proof may establish
+
+Subject to actual source/version evidence, one disposable local Miniflare D1 binding may establish only:
+
+- this migration's local SQLite/D1 parsing and schema objects;
+- local `STRICT`, BLOB type, primary-key, unique-key, foreign-key, and trigger behavior observed in the named scenario;
+- local direct `D1Client.batch` result ordering and all-or-nothing behavior observed for the named statements;
+- local primary-ledger read, head/event read, and replay over the local binding;
+- local byte normalization, fatal UTF-8 equality, accepted 0014 fold, descriptor boundary, and deterministic evidence; and
+- the local failure classifications produced by the future adapter for the listed cases.
+
+The proof must record the selected Miniflare version and package/lock source. The current repository root has a Wrangler-transitive Miniflare edge; a transitive edge is not a direct dependency decision for the future adapter and is not proof of its API.
+
+### 10.2 What it must not claim
+
+A local Miniflare binding does not prove:
+
+- remote D1 accepts this exact `UPDATE ... RETURNING`, `INSERT ... SELECT`, composite FK, `STRICT`, trigger, numbered-placeholder, BLOB, or batch result shape;
+- a D1 replica, session, bookmark, cache, or read-after-write path exists or is safe;
+- remote limits, concurrency scheduling, retry behavior, export/import, D1 migration tracking, Time Travel, backups, recovery, or provider availability;
+- Hyperdrive, Durable Object, R2, KV, Alchemy, Wrangler remote mode, Cloudflare account state, Worker bindings, routes, public reachability, production data, or deployment behavior; or
+- operator approval, cutover authority, rollback ownership, live tutor authority, or any external effect.
+
+### 10.3 Exact no-provider boundary
+
+The only allowed future runtime mutation is one disposable D1 database created by a local Miniflare binding in the named implementation worktree. The proof may use one loopback-only local process boundary at `127.0.0.1`; it must not expose a Worker route or public URL. The following are forbidden and are immediate `Drift`:
+
+```text
+wrangler --remote or any remote binding
+Cloudflare API, Alchemy plan/apply, provider account, or cloud state
+Hyperdrive, Durable Object, R2, KV, queues, service bindings, or a Worker route
+credentials, secrets, production data, remote data, or PII
+network fetch/socket to a provider or external service
+migration, export, import, restore, cutover, deploy, or route action
+```
+
+No local proof may use a deployment log or provider response as evidence. If the selected local harness requires a network socket beyond the loopback process boundary, or if any provider/credential attempt occurs, stop the proof, preserve sanitized facts, and enter `Drift`.
+
+## 11. Historical implementation capsule and current handoff
+
+The following capsule is the historical implementation contract. Its named implementation is complete and integrated on the canonical line, but no frozen/open one-to-one PR exists.
+
+Canonical provenance is `7ddca9eb18c307f7c6baf47134793eda5c299db6` (source candidate) → `9a166a327a21924537a3a3ac23ede88619b64c98` (canonical D1 integration) → `beff9154e8efb94c641b6cd6f8d65384ae0110f8` (provenance repair) → `ab95b5d36f515d1b60945b9d77a17a7519281493` (final head).
+
+### 11.1 Historical writer role and one PR
+
+- **Role:** one tutor-event persistence writer.
+- **Objective:** implement the exact local journey in §8 and provide sanitized evidence in one one-to-one PR.
+- **Suggested branch:** `impl/0017-tutor-d1-event-store-proof`; the feature lead records the actual branch/worktree/base when the PR capsule is frozen.
+- **One-to-one rule:** one implementation PR, one blind-first verifier, no bundled Worker, route, provider, backfill, deployment, or unrelated domain change.
+- **Superseded historical review:** `agent://TutorD1CodeReview0017` marked candidate `4c79fbae8a6d734e44443b1d5a1f7115b4a5ff84` **BLOCKED** for a resolver-derived lock-graph repair. The repair and review are closed by the canonical chain and the PASS reviews named in Metadata.
+
+### 11.2 Future owned and forbidden paths
+
+| Future path/resource | Capsule disposition | Exact reason |
+|---|---|---|
+| `packages/domain/src/tutor/**` | Owned | D1 adapter, schema migration file, local proof runner, BLOB boundary, replay bridge, and sanitized fixture harness stay beside accepted 0014 tutor code. No other domain source or second model. |
+| `packages/domain/package.json` | Owned only for the two named direct dependency keys and the proof-script key | The candidate may add only direct `@effect/sql-d1` beta.107 and `miniflare` `4.20260706.0` edges plus the §11.3 proof script, with no other manifest/package dependency edges and all unrelated keys preserved. |
+| `bun.lock` | Owned only for the exact resolver-derived lock update for the two named direct dependencies | Bun may mechanically re-hoist the exact graph described in §11.3, including its named transitive roots, only when every pre-existing consumer remains resolvable and the exact diff is recorded/reviewed. No unrelated manual refresh is allowed. |
+| `packages/domain/src/index.ts`, root `package.json`, root scripts/config, other packages/apps, and all existing 0014 files outside the successor changes | Read-only | No public API, root graph, unrelated domain, server, SDK, UI, or implementation authority is needed for this local proof. |
+| `docs/decisions/0002-tutor-event-log-persistence.md`, charter, lifecycle, domain model, and 0014 spec | Read-only authority | A conflict is `Drift`; the writer must not edit the easiest authority. |
+| `/srv/share/projects/effect/**` | Read-only external source authority | Verify source/hash; never vendor, patch, install, or modify it. |
+| Miniflare state, logs, caches, generated evidence | Disposable | Delete/discard before handoff. No generated evidence file is committed. |
+| Provider, remote, production, route, credentials, data, deployment, and operator resources | Forbidden | No authority or boundary in this capsule. |
+
+### 11.3 Future direct dependency and lock contract
+
+The future implementation may import only the named direct dependencies. The Bun resolver may emit the exact mechanically derived transitive lock graph described below; code and manifest dependency edges must not rely on undeclared direct packages:
+
+- Add direct runtime dependency `@effect/sql-d1` at exact `4.0.0-beta.107` only if the adapter imports `D1Client`/`D1Client.layer` from that package. This is direct because the implementation owns the D1 API capability and must pin the source-verified beta; a Wrangler or another package's transitive dependency is not an acceptable API edge.
+- Add direct development/proof dependency `miniflare` at the source-verified local Effect edge `4.20260706.0` if the proof imports Miniflare to create its local D1 binding. The local Effect `packages/sql/d1/package.json` declares `^4.20260706.0`, and `/srv/share/projects/effect/pnpm-lock.yaml` resolves `miniflare@4.20260706.0` with integrity `sha512-UiqGo9Es/D7kJvDVpjhTQ/M2ppCSCsRc5EEKec6i4BvnCkFCRaZHRmFkMHzLhlg+daSZ+zvBaycWmgLZHn/1tQ==`. This is a dependency rationale, not evidence that the current mono-web root lock already provides that edge. If a source-verified implementation avoids importing Miniflare directly, it must document the alternative and must not add an unnecessary direct edge.
+- Add one package proof script, `proof:d1`, targeting the local proof runner, and sequence it after the existing team and 0014 tutor fixture commands in `packages/domain/package.json`'s `test` script only if the accepted future runner is part of the package test gate. No other manifest key, version, export, or script may change.
+- Update `bun.lock` only with the exact resolver output required by those two direct dependencies and the proof script. The permitted mechanical graph may re-hoist `miniflare` `5.20260804.0-alpha` to `4.20260706.0` and add/re-root its `sharp`, `undici`, `@emnapi`, and `@img` transitive roots while preserving every pre-existing consumer version in nested entries. This is allowed only when the manifest's direct dependency changes remain exactly `@effect/sql-d1` `4.0.0-beta.107` and `miniflare` `4.20260706.0`, no other manifest/package dependency edge changes, every pre-existing consumer version remains resolvable, the exact transitive diff is recorded and independently reviewed, and no unrelated manual lock refresh occurs.
+- Do not add generic `@effect/sql`, `SqlEventJournal`, `Migrator`, a second ORM, a provider SDK, a Worker package, or a remote D1 client.
+
+The exact mechanically resolver-derived graph above is an explicit capsule exception, not arbitrary lock authority. If any condition is not met, stop at `Drift` and request a capsule revision; do not silently broaden the manifest or lock paths.
+If package resolution cannot provide the exact source-verified API without the named direct edges and this exact reviewed resolver graph, stop at `Drift` and request a capsule revision. Do not silently broaden the package or lock paths.
+
+### 11.4 Future handoff contents
+
+Before the future writer starts, the feature lead must hand off:
+
+1. this accepted spec, the exact product-lead acceptance record, and the unchanged ADR/0014 authority references;
+2. a fresh worktree, branch, and base commit recorded in the PR;
+3. the allowed/forbidden path table and direct dependency/lock decision;
+4. the exact fixture/head token and the numbered §8 scenarios;
+5. the local Effect beta.107 source/version/hash facts and a source-verified Miniflare version/capability record;
+6. the no-provider boundary and absence of operator authorization;
+7. the evidence destination, sanitization rules, deterministic canonicalization, and rollback/discard path; and
+8. a named blind-first verifier who receives the frozen spec and evidence before author rationale.
+
+The current handoff reports source candidate `7ddca9e`, canonical integration `9a166a3`, provenance repair `beff915`, final head `ab95b5d`, final parent `beff915`, changed paths, package/lock edges, local proof evidence, closed Drift, and clean tracked/ignored status. It must not present this local proof as remote, provider, production, Worker, route, cutover, or operator evidence.
+
+## 12. Entry gate and definition of done
+
+### 12.1 Current lifecycle disposition
+
+Implementation and local deterministic evidence are complete at canonical final head `ab95b5d36f515d1b60945b9d77a17a7519281493`, whose parent is `beff9154e8efb94c641b6cd6f8d65384ae0110f8`. The implementation source candidate was `7ddca9eb18c307f7c6baf47134793eda5c299db6`; canonical D1 integration is `9a166a327a21924537a3a3ac23ede88619b64c98`.
+
+- Product-lead acceptance covers the intent and this lifecycle/evidence revision. It does not accept implementation as a provider, remote, production, or operator action.
+- The canonical implementation paths are `packages/domain/src/tutor/d1-proof.ts`, `packages/domain/src/tutor/d1.ts`, `packages/domain/src/tutor/migrations/0001-tutor-event-store.sql`, `packages/domain/package.json`, and the resolver-derived `bun.lock` update.
+- The proof passed 23 cases twice with byte-identical canonical evidence at `ab95b5d36f515d1b60945b9d77a17a7519281493`: 110896 bytes and SHA-256 `81d2a752d34c01e6a09e5e0f54c2d56d528a45b51551087583fb07ffa2456985`.
+- Runtime PASS is recorded by `agent://CanonicalRepairRuntime1718` at canonical `ab95b5d36f515d1b60945b9d77a17a7519281493`. Superseded source-candidate runtime evidence from `agent://TutorD1AcceptanceRuntime0017` was 23 cases, 110684 bytes, SHA-256 `e5899fb8ff687f3108c3d2211af997ddb2cc2ce80c7ebe37b58ce76649c4a909`.
+- All linked blocking Drift, including the prior resolver-derived lock-graph review blocker, is closed. The prior `4c79fbae...` BLOCKED review remains historical and is superseded.
+- No frozen/open one-to-one PR exists. Therefore the lifecycle remains `Building`; it is not `Experienceable`, `Conforming`, `Release-ready`, or `Operating`.
+- No provider, remote, production, route, Worker, data, credential, deployment, or operator authority is granted.
+
+`Building` is current for the completed canonical implementation and evidence capsule. `Experienceable` requires the lifecycle authority's frozen/open one-to-one PR gate; `Conforming` is forbidden without that gate and independent verification of the PR.
+
+### 12.2 Definition of done for the eventual PR
+
+The future PR is complete only when:
+
+- only the future owned paths changed, with any package/lock edits limited to §11.3 and justified in the PR;
+- the exact migration runs without explicit `BEGIN TRANSACTION`/`COMMIT` and produces the required schema/triggers;
+- the exact seed and head token fold to the accepted 0014 state;
+- `ConductInterview` appends v4 once through the numbered three-statement D1 batch and exposes its descriptor only after commit;
+- global ledger lookup precedes stream/version/terminal validation; exact duplicate and changed cross-stream duplicate have the accepted outcomes;
+- same-version and multi-advance races, FK/unique failures, and stale/terminal/missing-head/divergence cases prove no partial candidate batch remains;
+- trigger messages, BLOB normalization, fatal decode/re-encode, persisted unknown schema/type, gap, `occurred_at` rewind, correlation, and indexed/envelope mismatch (including decoded envelope stream mismatch), plus adapter row-array/fold-input duplicate event ID/version and cross-stream cases with their explicit local limit, all fail closed;
+- replay uses the pure accepted fold and returns the accepted projection without a status/projection table or second model;
+- two clean identical local runs render byte-identical canonical evidence and SHA-256 digest with sanitized provenance and limits;
+- the proof uses one disposable local Miniflare D1 binding and no provider/remote/production/Worker/route/credential/data effect;
+- all temporary state/logs/cache/generated files are removed or ignored; the worktree is clean; and
+- an independent blind-first verifier passes the named journey with no linked `Drift`.
+
+This docs-only spec task intentionally performs none of the eventual test/build/install/formatter/linter/runtime checks. The absence of such checks here is not implementation evidence.
+
+## 13. Falsifiers
+
+Any condition below is a falsifier. The future writer stops the lane, preserves sanitized evidence, and enters `Drift`; it does not weaken the contract.
+
+### 13.1 Accepted resolver-derived lock exception
+
+The implementation-review blocker is resolved only for this exact mechanical resolver outcome: direct manifest dependency changes are limited to `@effect/sql-d1` `4.0.0-beta.107` and `miniflare` `4.20260706.0`; no other manifest/package dependency edge changes; every pre-existing consumer version remains resolvable in nested lock entries; the exact `miniflare` `5.20260804.0-alpha` → `4.20260706.0` re-hoist and `sharp`/`undici`/`@emnapi`/`@img` transitive-root diff is recorded and reviewed; and no unrelated manual refresh is present. This exception does not authorize any other lock graph, package edge, provider, remote, runtime, or deployment action.
+
+| Falsifier | Required response |
+|---|---|
+| A second live writer or dual-write path targets MySQL and D1. | Stop. Reject the capsule; current Symfony/MySQL remains pre-cutover authority. |
+| A route, Worker, provider, credential, remote binding, production data, or public preview is touched by the local proof. | Discard the proof and enter `Drift`; repeat only with one disposable local Miniflare D1 binding. |
+| `command_receipts` is stream-scoped or lookup occurs after stream/version/terminal validation. | Reject the schema/order; restore global command-ID lookup first. |
+| Same global command ID with identical bytes is accepted a second time, or is rejected because the stream is terminal. | Reject duplicate precedence; return stored observation before terminal checks. |
+| Same global command ID with changed bytes, including changed stream, is accepted. | Reject idempotency; return `DuplicateCommandConflict` with no state change. |
+| Event IDs are treated as globally unique or a global event-ID format is invented. | Enter `Drift`; retain composite stream/event identity and defer global event-ID decision. |
+| A missing head is created by `ConductInterview`. | Reject the command path; return `EMPTY_STREAM` and keep stream creation separate. |
+| Head version/token disagrees with the folded event log and the append repairs it. | Enter `Drift`; stop and preserve the inconsistent rows. |
+| A stale CAS leaves an event or receipt, or a zero-row CAS commits without the FK rollback. | Reject the batch protocol; prove complete rollback before any further work. |
+| Statement 0 omits expected version or expected `last_command_id`, or Statement 1 omits the new head/version/token predicates. | Reject the CAS and its race evidence. |
+| Multi-advance or older-event race attaches a receipt to an event with another causation ID. | Reject the composite FK proof; require rollback and second-ledger classification. |
+| Any uniqueness or foreign-key failure is converted into success or hidden as a duplicate without the required ledger read. | Reject the adapter; surface the constraint and enter `Drift` when unclassified. |
+| Batch statements, binds, or result indexes are reordered; named placeholders appear; result shape is guessed without observation. | Reject the adapter and re-record exact numbered SQL/bind/result evidence. |
+| Descriptor bytes are computed after the batch, exposed before commit, interpreted during replay, or given a destination/provider. | Stop the effect lane; keep descriptor inert and commit-gated. |
+| A status/projection table or receipt-derived status owner is added. | Reject the schema; pure 0014 fold remains sole projection owner. |
+| Replay accepts unknown schema/type, a persisted gap/rewind/correlation/indexed-envelope mismatch (including decoded envelope stream mismatch), or adapter row-array/fold-input duplicate event ID/version/cross-stream input. | Fail closed and enter `Drift`; do not guess historical payloads or repair rows, and retain the explicit local persistence/query limit. |
+| BLOB columns accept strings/objects, `number[]` is not normalized, invalid UTF-8 is replaced, or re-encode bytes differ. | Reject the adapter; return typed integrity failure before fold/byte equality. |
+| Immutable event/receipt update or delete succeeds, or trigger messages differ without recorded equivalent proof. | Reject the migration and restore both `RAISE(ABORT)` trigger behaviors. |
+| Migration/import includes `BEGIN TRANSACTION` or `COMMIT`, uses generic `Migrator`, or D1 calls `SqlClient.withTransaction`. | Reject the implementation; use D1-compatible implicit migration and direct `D1Client.batch`. |
+| Generic `SqlEventJournal` supplies schema, generated IDs, conflict-hiding inserts, handler ordering, or transaction semantics. | Reject the implementation; do not create a second persistence contract. |
+| Local Miniflare output is presented as remote D1, session, replica, provider, deployment, Worker, route, production, or operator proof. | Reject the claim and retain only the named local observation. |
+| Two identical runs differ in canonical evidence bytes/digest, key order, event order, provenance, or limits. | Reject deterministic evidence; remove clock/random/environment/path leakage. |
+| A package or lock edge is added manually beyond the two named direct dependencies, any condition of the exact resolver-derived graph exception is false, or an unrelated manual lock refresh occurs. | Stop at `Drift`; retain only the exact reviewed mechanical graph and request a capsule revision. |
+| Writer changes an authority, broadens paths, edits unrelated source, or hides a source/API disagreement. | Stop at the capsule boundary and enter `Drift`; product lead routes the correction. |
+| A deployment/log/review/install result is presented as journey, domain, persistence, provider, or production proof. | Reject the evidence boundary and request the named scenario observation. |
+
+## 14. Rollback, Drift, and lifecycle
+
+### 14.1 Local rollback
+
+The future proof uses disposable Miniflare state. On migration, SQL, adapter, replay, BLOB, race, or evidence failure:
+
+1. stop the local proof;
+2. preserve only sanitized input/output facts, source/version/hash facts, scenario ID, and bounded counts;
+3. discard the local D1 binding and generated state/log/cache;
+4. do not retry a failed write before the required primary ledger read;
+5. notify the feature lead/product lead and owning source authority; and
+6. enter `Drift` with the conflicting artifact, observation, owner, and return path.
+
+There is no remote restore, database rollback, route change, or provider destroy in this capsule. The existing pre-cutover Symfony/MySQL authority is not changed by local state disposal.
+
+### 14.2 Drift path
+
+Enter `Drift` when an authority, domain law, Effect source/API, local D1 result, SQL constraint, migration result, replay result, Miniflare boundary, package edge, evidence digest, or operator boundary disagrees with this spec. Do not weaken a constraint to remove the entry. The product lead routes an intent disagreement back to `Specified`; an implementation correction returns to `Building` only after the accepted intent and base are stable. A predecessor or shared-resource Drift blocks this successor.
+
+### 14.3 Lifecycle states
+
+- **`Specified` (completed):** this file contains the one journey, authority routing, exact fixture, schema, batch protocol, replay, evidence, limits, capsule, entry gate, falsifiers, rollback, and handoff; product-lead acceptance and independent review are recorded at reviewed HEAD `988ed2a`.
+- **`Ready` (historical and completed):** product-lead acceptance, predecessor confirmation, direct dependency decision, and evidence destination were recorded before implementation.
+- **`Building` (current):** implementation and local deterministic evidence are complete at canonical final head `ab95b5d36f515d1b60945b9d77a17a7519281493`; all linked blocking Drift is closed, but no frozen/open one-to-one PR exists.
+- **Building boundary:** the implementation and evidence remain inside the named local capsule; no provider, remote, production, route, Worker, deployment, or operator effect is allowed.
+- **`Experienceable` (not entered):** requires the lifecycle authority's frozen/open one-to-one PR and its complete objective evidence.
+- **`Conforming` (not entered and not claimed):** forbidden until that PR gate and independent verification exist.
+- **`Release-ready`/`Operating` (not entered and not implied):** this local proof has no release, deployment, route, production, provider, or operator authority.
+
+This spec is `Building` with implementation and deterministic local evidence complete. Acceptance, implementation review, runtime observation, and any future PR gate remain separate artifacts and roles.
+
+## 15. Exact sources and dependency notes
+
+### Repository and accepted predecessor sources
+
+- `/srv/share/projects/vektorprogrammet/docs/decisions/0002-tutor-event-log-persistence.md`, accepted; SHA-256 `94a2dbe93d353ddf98af784d3d6a66903c69631f8adc656c07f98a329491c830`; §§3–9 supply stream identity, schema, append, replay, beta.107 boundary, and all 21 local successor cases.
+- `design-specs/0014-tutor-event-envelope-tracer.md` at base commit `a8dafe618907dfd623718802fdaf5712d55f70d4`; base file SHA-256 `270315bb1e3727a3668b025e1a888f95b4247955ba28516a42a5d399c017539b`.
+- Accepted 0014 core code at that base: `packages/domain/src/tutor/schema.ts` SHA-256 `e355c580c69e2eb50d04cfb32cb0e8561eeee12b369a84245c7fd3fc5b607f20`; `tracer.ts` SHA-256 `880eebeffb1aa4bed0a825fca03587e9b11507dd3accb31dc0ed1a1ed0805fad`; `fixture.ts` SHA-256 `246dd484c8ddd3d7adf18ddb0634635bf32c7555d468692228b64b1bce77cda2`; `evidence.ts` SHA-256 `f8ad64ff61fba02c27888690ed4de6327c83d50c6b0a683e07e3448bb8d0a3c9`.
+- `/srv/share/projects/vektorprogrammet/docs/product-lead-charter.md`, `/srv/share/projects/vektorprogrammet/docs/agentic-development-lifecycle.md`, and `/srv/share/projects/vektorprogrammet/docs/domain-model.md` are the current authority locators; this file does not copy their normative text.
+
+### Local Effect beta.107 sources
+
+- `/srv/share/projects/effect/packages/sql/d1/package.json`, version `4.0.0-beta.107`, SHA-256 `e4e2ccecc5a7e11dd08892cd5cf7a15568a27767a51e2b7ff688e8444b98236a`.
+- `/srv/share/projects/effect/packages/sql/d1/src/D1Client.ts`, SHA-256 `33d086b2b5599349e012f93241d40f079ff78d09ddea00857744217e39b8647e`; `D1Client.batch`/binding/result-order lines 58–89 and 130–188; unsupported transaction and `layer` lines 315–337 and 388–402.
+- `/srv/share/projects/effect/packages/effect/src/unstable/sql/Statement.ts`, SHA-256 `d0217382c9cded3a4f143058461b96aecf18c0f2daedd7995e726831d7cc12f5`.
+- `/srv/share/projects/effect/packages/effect/src/unstable/eventlog/SqlEventJournal.ts`, SHA-256 `e7912dad2892ce246a1143389d17b9d8277df2eb204b92c4e3808437c1d0b9a8`.
+- `/srv/share/projects/effect/packages/effect/src/unstable/sql/Migrator.ts`, SHA-256 `c94e7d36a4d253210e76e694bde656aeace439e541e503b9442e06bf95878de9`.
+- `/srv/share/projects/effect/packages/effect/src/unstable/sql/SqlClient.ts`, SHA-256 `ec65f43418586cdf41c6389420da8f5b05000e88a017ddb4d77627e2b8b0ebfc`.
+- `/srv/share/projects/effect/pnpm-lock.yaml` local D1 development edge: `miniflare@4.20260706.0`, integrity `sha512-UiqGo9Es/D7kJvDVpjhTQ/M2ppCSCsRc5EEKec6i4BvnCkFCRaZHRmFkMHzLhlg+daSZ+zvBaycWmgLZHn/1tQ==`; this is not a current mono-web lock change.
+
+### Official capability references routed by ADR 0002
+
+- [Cloudflare D1 Database](https://developers.cloudflare.com/d1/worker-api/d1-database/) — D1 batch/session documentation; remote proof remains out of scope.
+- [Cloudflare D1 prepared statements](https://developers.cloudflare.com/d1/worker-api/prepared-statements/) — numbered/anonymous parameter boundary; this local spec requires numbered placeholders.
+- [Cloudflare D1 foreign keys](https://developers.cloudflare.com/d1/sql-api/foreign-keys/) — foreign-key behavior; local observation is not remote proof.
+- [Cloudflare D1 local development](https://developers.cloudflare.com/d1/best-practices/local-development/) — local Miniflare separation; no remote mode here.
+- [Cloudflare D1 migrations](https://developers.cloudflare.com/d1/reference/migrations/) — ordered migration concept; this proof omits explicit transaction delimiters.
+- [Cloudflare D1 export/import](https://developers.cloudflare.com/d1/best-practices/import-export-data/) and [Time Travel](https://developers.cloudflare.com/d1/reference/time-travel/) — explicit remote successors, not local claims.
+
+No source above grants provider, remote, production, route, Worker, data, credential, or operator authority.
+
+## 16. Current disposition and future handoff summary
+
+Current disposition is **`Building` / canonical implementation complete at `ab95b5d36f515d1b60945b9d77a17a7519281493` (parent `beff9154e8efb94c641b6cd6f8d65384ae0110f8`) / 23-case local proof PASS / 110896 evidence bytes / SHA-256 `81d2a752d34c01e6a09e5e0f54c2d56d528a45b51551087583fb07ffa2456985` / all linked blocking Drift closed / no frozen-open one-to-one PR**.
+
+The handoff record contains:
+
+```text
+source candidate 7ddca9eb18c307f7c6baf47134793eda5c299db6 (parent d04f237b3f3ec6adb0200fca874773976460d477)
+canonical D1 integration 9a166a327a21924537a3a3ac23ede88619b64c98 (parent e214c872841a90279e6525354ebe1f50232105fa)
+canonical provenance repair beff9154e8efb94c641b6cd6f8d65384ae0110f8
+canonical final head ab95b5d36f515d1b60945b9d77a17a7519281493 (parent beff9154e8efb94c641b6cd6f8d65384ae0110f8)
+changed paths: packages/domain/src/tutor/d1-proof.ts, packages/domain/src/tutor/d1.ts, packages/domain/src/tutor/migrations/0001-tutor-event-store.sql, packages/domain/package.json, bun.lock
+proof: canonical runtime PASS at `ab95b5d36f515d1b60945b9d77a17a7519281493`: 23 cases; 110896 bytes; SHA-256 81d2a752d34c01e6a09e5e0f54c2d56d528a45b51551087583fb07ffa2456985; repeated digest identical
+superseded source-candidate runtime: `agent://TutorD1AcceptanceRuntime0017`; 23 cases; 110684 bytes; SHA-256 e5899fb8ff687f3108c3d2211af997ddb2cc2ce80c7ebe37b58ce76649c4a909
+code review PASS: TutorD1AcceptanceCode0017; CanonicalRepairCodeReview1718
+linked blocking Drift: closed
+external authority: none; no provider, remote, production, route, Worker, deployment, credential, data, or operator action
+```
+
+Before a one-to-one PR opens, the feature lead must freeze this spec, attach the sanitized evidence and named reviews, and record the PR's exact changed paths. Until then, no writer may call this capsule `Experienceable`, `Conforming`, `Release-ready`, or `Operating`, or treat it as D1/provider/remote/production/route authority.

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -13,16 +13,19 @@
   },
   "scripts": {
     "report": "bun run src/main.ts",
-    "test": "bun run src/main.ts --fixtures && bun run src/tutor/main.ts --fixtures",
+    "proof:d1": "bun run src/tutor/d1-proof.ts",
+    "test": "bun run src/main.ts --fixtures && bun run src/tutor/main.ts --fixtures && bun run proof:d1",
     "check-types": "tsc --noEmit",
     "build": "tsc --noEmit",
     "lint": "oxlint"
   },
   "dependencies": {
+    "@effect/sql-d1": "4.0.0-beta.107",
     "effect": "4.0.0-beta.107"
   },
   "devDependencies": {
     "@types/node": "^22",
+    "miniflare": "4.20260706.0",
     "oxlint": "^1.41.0",
     "typescript": "^5"
   }

--- a/packages/domain/src/tutor/d1-proof.ts
+++ b/packages/domain/src/tutor/d1-proof.ts
@@ -1,0 +1,1000 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { Miniflare } from "miniflare";
+import { Effect } from "effect";
+import {
+  canonicalJson,
+  canonicalJsonBytes,
+  sha256Hex,
+} from "./evidence.js";
+import {
+  REPLAY_SQL,
+  type BatchPlan,
+  type D1Binding,
+  type D1AppendResult,
+  type ReplayEventRow,
+  type ReplayResult,
+  type TutorD1Failure,
+  type TutorD1Store,
+  makeTutorD1Store,
+  normalizeBlobBytes,
+  runWithTutorD1,
+  validateReplayRows,
+} from "./d1.js";
+import { projectFoldedState } from "./tracer.js";
+import type { CommandObservation } from "./tracer.js";
+import type { Descriptor, EventEnvelopeV1, StreamKey } from "./schema.js";
+import {
+  FIXTURE_COMMAND,
+  FIXTURE_CORRELATION_ID,
+  FIXTURE_DEPARTMENT_ID,
+  FIXTURE_ID,
+  FIXTURE_PERSON_ID,
+  FIXTURE_SEED_EVENTS,
+} from "./fixture.js";
+const PINNED_BUN_VERSION = "1.3.10";
+const EFFECT_VERSION = "4.0.0-beta.107";
+const MINIFLARE_VERSION = "4.20260706.0";
+const SPEC_ID = "0017";
+const BASE_COMMIT = "a8dafe618907dfd623718802fdaf5712d55f70d4";
+const SOURCE_CANDIDATE_PARENT = "266185e98d22718576653df9973ece8246da124a";
+const SOURCE_CANDIDATE_COMMIT = "7ddca9eb18c307f7c6baf47134793eda5c299db6";
+const CANONICAL_INTEGRATION_BASE = "0f09064d4d85039f51127bd25b6501b71696980e";
+const CANONICAL_D1_INTEGRATION_COMMIT = "9a166a327a21924537a3a3ac23ede88619b64c98";
+const PREDECESSOR_COMMIT = "a8dafe618907dfd623718802fdaf5712d55f70d4";
+const ADR_SHA256 = "94a2dbe93d353ddf98af784d3d6a66903c69631f8adc656c07f98a329491c830";
+const D1_CLIENT_SOURCE_HASH = "33d086b2b5599349e012f93241d40f079ff78d09ddea00857744217e39b8647e";
+const STATEMENT_SOURCE_HASH = "d0217382c9cded3a4f143058461b96aecf18c0f2daedd7995e726831d7cc12f5";
+const SQL_EVENT_JOURNAL_SOURCE_HASH = "e7912dad2892ce246a1143389d17b9d8277df2eb204b92c4e3808437c1d0b9a8";
+const MIGRATOR_SOURCE_HASH = "c94e7d36a4d253210e76e694bde656aeace439e541e503b9442e06bf95878de9";
+const SQL_CLIENT_SOURCE_HASH = "ec65f43418586cdf41c6389420da8f5b05000e88a017ddb4d77627e2b8b0ebfc";
+const D1_BINDING_NAME = "TUTOR_D1";
+
+const stream: StreamKey = FIXTURE_COMMAND.stream;
+
+interface LocalPrepared {
+  bind: (...values: ReadonlyArray<unknown>) => LocalPrepared;
+  all: <A extends Record<string, unknown>>() => Promise<{ readonly results: ReadonlyArray<A> }>;
+  run: () => Promise<unknown>;
+}
+
+interface LocalBinding {
+  prepare: (query: string) => LocalPrepared;
+}
+
+interface LocalRuntime {
+  readonly miniflare: Miniflare;
+  readonly db: LocalBinding;
+}
+let activeRuntime: LocalRuntime | undefined;
+
+interface HeadSnapshot {
+  readonly current_version: number;
+  readonly last_command_id: string | null;
+}
+
+interface RowCounts {
+  readonly stream_heads: number;
+  readonly tutor_events: number;
+  readonly command_receipts: number;
+}
+
+const readFixtureHead = async (db: LocalBinding): Promise<HeadSnapshot | null> => {
+  const rows = await dbRows<Record<string, unknown>>(
+    db,
+    `SELECT current_version, last_command_id
+     FROM stream_heads
+     WHERE person_id = ?1
+       AND department_id = ?2
+       AND semester_year = ?3
+       AND semester_term = ?4;`,
+    [stream.personId, stream.cycle.departmentId, stream.cycle.semester.year, stream.cycle.semester.term],
+  );
+  const row = rows[0];
+  if (row === undefined) return null;
+  assert(Number.isInteger(row.current_version), "head snapshot version is not an integer");
+  assert(row.last_command_id === null || typeof row.last_command_id === "string", "head snapshot token is not text/null");
+  return { current_version: Number(row.current_version), last_command_id: row.last_command_id as string | null };
+};
+
+interface CaseRecord {
+  readonly caseId: string;
+  readonly status: "accepted" | "rejected" | "stale" | "terminal" | "duplicate" | "duplicate-conflict" | "drift";
+  readonly reasonCode: string;
+  readonly commandId: string;
+  readonly before: RowCounts;
+  readonly after: RowCounts;
+  readonly rows: ReadonlyArray<string>;
+  readonly details: Readonly<Record<string, unknown>>;
+}
+
+interface D1Evidence {
+  readonly formatVersion: 1;
+  readonly specId: typeof SPEC_ID;
+  readonly baseCommit: string;
+  readonly adrSha256: string;
+  readonly predecessorCommit: string;
+  readonly fixtureId: string;
+  readonly schemaMigrationId: string;
+  readonly schemaHash: string;
+  readonly localEffectVersion: string;
+  readonly localEffectSourceHashes: Readonly<Record<string, string>>;
+  readonly localMiniflareVersion: string;
+  readonly correlationId: string;
+  readonly stream: StreamKey;
+  readonly seedHead: Readonly<Record<string, unknown>>;
+  readonly seedEvents: ReadonlyArray<Readonly<Record<string, unknown>>>;
+  readonly batch: Readonly<Record<string, unknown>>;
+  readonly cases: ReadonlyArray<CaseRecord>;
+  readonly replay: Readonly<Record<string, unknown>>;
+  readonly projection: Readonly<Record<string, unknown>>;
+  readonly effectDescriptors: ReadonlyArray<Descriptor>;
+  readonly rowCounts: Readonly<Record<string, unknown>>;
+  readonly limits: ReadonlyArray<string>;
+  readonly provenance: Readonly<Record<string, unknown>>;
+}
+
+interface RenderedEvidence {
+  readonly document: D1Evidence;
+  readonly canonicalJson: string;
+  readonly bytes: Uint8Array;
+  readonly digest: string;
+}
+
+function assert(condition: boolean, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+const errorTag = (error: unknown): string =>
+  typeof error === "object" && error !== null && "_tag" in error && typeof error._tag === "string"
+    ? error._tag
+    : error instanceof Error
+      ? error.name
+      : "UnknownError";
+
+const errorReason = (error: unknown): string =>
+  typeof error === "object" && error !== null && "reasonCode" in error && typeof error.reasonCode === "string"
+    ? error.reasonCode
+    : error instanceof Error
+      ? error.name
+      : "UNKNOWN";
+
+const expectFailure = async <E>(
+  promise: Promise<unknown>,
+  predicate: (error: E) => boolean,
+  message: string,
+): Promise<E> => {
+  try {
+    await promise;
+  } catch (error) {
+    if (predicate(error as E)) return error as E;
+    throw new Error(`${message}: observed ${errorTag(error)}:${errorReason(error)}`);
+  }
+  throw new Error(`${message}: operation unexpectedly succeeded`);
+};
+
+const dbExec = (db: LocalBinding, sql: string, binds: ReadonlyArray<unknown> = []): Promise<unknown> =>
+  db.prepare(sql).bind(...binds).run();
+
+const dbRows = async <A extends Record<string, unknown>>(
+  db: LocalBinding,
+  sql: string,
+  binds: ReadonlyArray<unknown> = [],
+): Promise<ReadonlyArray<A>> => (await db.prepare(sql).bind(...binds).all<A>()).results;
+
+const rowCounts = async (db: LocalBinding): Promise<RowCounts> => {
+  const rows = await dbRows<Record<string, number>>(
+    db,
+    `SELECT
+      (SELECT COUNT(*) FROM stream_heads) AS stream_heads,
+      (SELECT COUNT(*) FROM tutor_events) AS tutor_events,
+      (SELECT COUNT(*) FROM command_receipts) AS command_receipts;`,
+  );
+  const row = rows[0];
+  assert(row !== undefined, "count query returned no row");
+  return {
+    stream_heads: Number(row.stream_heads),
+    tutor_events: Number(row.tutor_events),
+    command_receipts: Number(row.command_receipts),
+  };
+};
+
+const openRuntime = async (): Promise<LocalRuntime> => {
+  const miniflare = new Miniflare({ modules: true, script: "", d1Databases: [D1_BINDING_NAME] });
+  const db = (await miniflare.getD1Database(D1_BINDING_NAME)) as unknown as LocalBinding;
+  return { miniflare, db };
+};
+
+const migrationSql = async (): Promise<string> =>
+  readFile(fileURLToPath(new URL("./migrations/0001-tutor-event-store.sql", import.meta.url)), "utf8");
+
+const applyMigration = async (db: LocalBinding, sql: string): Promise<void> => {
+  const statements = sql.split(/;\s*(?=CREATE TABLE|CREATE TRIGGER)/);
+  for (const statement of statements) {
+    const sqlText = statement.trim();
+    await db.prepare(sqlText.endsWith(";") ? sqlText : `${sqlText};`).run();
+  }
+};
+
+const seedStream = async (
+  db: LocalBinding,
+  seedEvents: ReadonlyArray<EventEnvelopeV1> = FIXTURE_SEED_EVENTS,
+  headVersion = 3,
+  headToken: string | null = FIXTURE_ID,
+): Promise<void> => {
+  await dbExec(
+    db,
+    `INSERT INTO stream_heads (person_id, department_id, semester_year, semester_term, current_version, last_command_id)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6);`,
+    [stream.personId, stream.cycle.departmentId, stream.cycle.semester.year, stream.cycle.semester.term, headVersion, headToken],
+  );
+  for (const event of seedEvents) {
+    await dbExec(
+      db,
+      `INSERT INTO tutor_events (
+        person_id, department_id, semester_year, semester_term, event_id, stream_version,
+        schema_version, event_type, envelope_bytes, occurred_at, causation_id, correlation_id
+      ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12);`,
+      [
+        event.stream.personId,
+        event.stream.cycle.departmentId,
+        event.stream.cycle.semester.year,
+        event.stream.cycle.semester.term,
+        event.eventId,
+        event.streamVersion,
+        event.schemaVersion,
+        event.eventType,
+        canonicalJsonBytes(event),
+        event.occurredAt,
+        event.causationId,
+        event.correlationId,
+      ],
+    );
+  }
+};
+const resetDatabase = async (db: LocalBinding): Promise<void> => {
+  for (const sql of [
+    "DROP TRIGGER IF EXISTS tutor_events_immutable_update;",
+    "DROP TRIGGER IF EXISTS tutor_events_immutable_delete;",
+    "DROP TRIGGER IF EXISTS command_receipts_immutable_update;",
+    "DROP TRIGGER IF EXISTS command_receipts_immutable_delete;",
+    "DROP TABLE IF EXISTS command_receipts;",
+    "DROP TABLE IF EXISTS tutor_events;",
+    "DROP TABLE IF EXISTS stream_heads;",
+  ]) {
+    await dbExec(db, sql);
+  }
+};
+const withMigration = async <A>(run: (runtime: LocalRuntime) => Promise<A>): Promise<A> => {
+  const ownsRuntime = activeRuntime === undefined;
+  const runtime = activeRuntime ?? await openRuntime();
+  try {
+    await resetDatabase(runtime.db);
+    await applyMigration(runtime.db, await migrationSql());
+    return await run(runtime);
+  } finally {
+    if (ownsRuntime) {
+      await runtime.miniflare.dispose();
+    }
+  }
+};
+
+const withSeed = async <A>(run: (runtime: LocalRuntime) => Promise<A>): Promise<A> =>
+  withMigration(async (runtime) => {
+    await seedStream(runtime.db);
+    return run(runtime);
+  });
+
+const withStore = async <A, E>(
+  db: LocalBinding,
+  operation: (store: TutorD1Store) => Effect.Effect<A, E>,
+): Promise<A> =>
+  runWithTutorD1(
+    db as unknown as D1Binding,
+    Effect.flatMap(makeTutorD1Store, operation),
+  );
+const append = (db: LocalBinding, input: unknown, options?: { readonly beforeBatch?: ((plan: BatchPlan) => Promise<void>) | undefined }): Promise<D1AppendResult> =>
+  withStore(db, (store) => store.appendAccepted(input, options));
+
+const readReplay = (db: LocalBinding): Promise<unknown> =>
+  withStore(db, (store) => store.readStream(stream));
+
+const caseRecord = (
+  caseId: string,
+  status: CaseRecord["status"],
+  reasonCode: string,
+  commandId: string,
+  before: RowCounts,
+  after: RowCounts,
+  rows: ReadonlyArray<string> = ["candidate"],
+  details: Readonly<Record<string, unknown>> = {},
+): CaseRecord => ({ caseId, status, reasonCode, commandId, before, after, rows, details });
+
+const conductedEventFor = (commandId: string, correlationId = FIXTURE_CORRELATION_ID): EventEnvelopeV1 => ({
+  schemaVersion: 1,
+  eventId: "evt-0014-004",
+  stream,
+  streamVersion: 4,
+  eventType: "InterviewConducted",
+  payload: {
+    scores: {
+      ...FIXTURE_COMMAND.scores,
+      conductedAt: "2026-08-11T09:03:00Z",
+    },
+  },
+  occurredAt: "2026-08-11T09:03:00Z",
+  causationId: commandId,
+  correlationId,
+});
+
+const descriptorFor = (commandId: string): Descriptor => ({
+  descriptorVersion: 1,
+  kind: "InterviewConductedDescriptor",
+  sourceEventId: "evt-0014-004",
+  causationId: commandId,
+  correlationId: FIXTURE_CORRELATION_ID,
+  idempotencyKey: "post-commit:evt-0014-004",
+});
+
+const observationFor = (commandId: string): CommandObservation => ({
+  outcome: "accepted",
+  commandId,
+  eventId: "evt-0014-004",
+  streamVersion: 4,
+  eventCount: 4,
+  descriptorCount: 1,
+  projection: {
+    projectionVersion: 1,
+    stream,
+    streamVersion: 4,
+    status: "completed",
+    eventTypes: ["ApplicationReceived", "InterviewInvited", "InterviewAccepted", "InterviewConducted"],
+    conductedAt: "2026-08-11T09:03:00Z",
+    lawRefs: ["T-INT-1", "S-INT-1", "T-INT-2", "R-APP-1"],
+  },
+  descriptor: descriptorFor(commandId),
+});
+
+const migrationCase = async (sql: string): Promise<CaseRecord> =>
+  withMigration(async ({ db }) => {
+    const before = await rowCounts(db);
+    const schemaRows = await dbRows<Record<string, unknown>>(
+      db,
+      `SELECT type, name, sql FROM sqlite_master WHERE type IN ('table', 'trigger') ORDER BY type, name;`,
+    );
+    const tableNames = schemaRows.filter((row) => row.type === "table").map((row) => String(row.name));
+    const triggerNames = schemaRows.filter((row) => row.type === "trigger").map((row) => String(row.name));
+    const requiredTables = ["command_receipts", "stream_heads", "tutor_events"];
+    assert(requiredTables.every((tableName) => tableNames.includes(tableName)), "migration table set mismatch");
+    assert(!/\bBEGIN\s+TRANSACTION\b|\bCOMMIT\b/i.test(sql), "migration contains explicit transaction delimiter");
+    const after = await rowCounts(db);
+    return caseRecord("adr-01-migration", "accepted", "MIGRATION_APPLIED", "migration", before, after, ["schema"], {
+      migrationOperation: "D1Database.prepare(...).run",
+      tableNames,
+      triggerNames,
+      strictTables: true,
+    });
+  });
+
+const seedCase = async (): Promise<CaseRecord> =>
+  withMigration(async ({ db }) => {
+    const before = await rowCounts(db);
+    await seedStream(db);
+    const after = await rowCounts(db);
+    const replay = (await readReplay(db)) as { readonly events: ReadonlyArray<EventEnvelopeV1>; readonly folded: { readonly events: ReadonlyArray<EventEnvelopeV1> } };
+    assert(replay.events.length === 3 && replay.folded.events.length === 3, "seed replay count mismatch");
+    assert(after.command_receipts === 0, "seed created receipt");
+    return caseRecord("adr-02-seed", "accepted", "SEED_ACCEPTED", FIXTURE_ID, before, after, ["fixture", "seed"], {
+      currentVersion: 3,
+      lastCommandId: FIXTURE_ID,
+      eventIds: replay.events.map((event) => event.eventId),
+      projectionStatus: "accepted",
+    });
+  });
+
+const appendAcceptedCase = async (): Promise<{ readonly record: CaseRecord; readonly result: D1AppendResult; readonly observation: CommandObservation; readonly plan: Readonly<Record<string, unknown>> }> =>
+  withSeed(async ({ db }) => {
+    const before = await rowCounts(db);
+    const result = await append(db, FIXTURE_COMMAND);
+    assert(result._tag === "AcceptedResult", "accepted command did not append");
+    assert(result.batchResults[0]?.length === 1, "CAS result did not contain one row");
+    const returned = result.batchResults[0]?.[0];
+    assert(returned?.current_version === 4 && returned.last_command_id === FIXTURE_COMMAND.commandId, "CAS result tuple mismatch");
+    const after = await rowCounts(db);
+    assert(after.stream_heads === before.stream_heads && after.tutor_events === before.tutor_events + 1 && after.command_receipts === before.command_receipts + 1, "accepted counts mismatch");
+    return {
+      result,
+      observation: result.observation,
+      plan: {
+        sql: result.batchPlan.statements.map((statement) => statement.sql),
+        binds: result.batchPlan.statements.map((statement) => statement.binds),
+        resultIndexes: [0, 1, 2],
+        returned,
+      },
+      record: caseRecord("adr-04-accepted-append", "accepted", "APPEND_COMMITTED", FIXTURE_COMMAND.commandId, before, after, ["candidate"], {
+        resultZero: returned,
+        eventId: result.event.eventId,
+        newVersion: result.batchPlan.newVersion,
+        descriptorExposedAfterCommit: true,
+      }),
+    };
+  });
+
+const runJourney = async (schemaHash: string): Promise<D1Evidence> => {
+  const runtime = await openRuntime();
+  activeRuntime = runtime;
+  try {
+    const cases: Array<CaseRecord> = [];
+  cases.push(await migrationCase(await migrationSql()));
+  cases.push(await seedCase());
+  cases.push(
+    await withMigration(async ({ db }) => {
+      const before = await rowCounts(db);
+      const missingCommand = { ...FIXTURE_COMMAND, commandId: "cmd-0017-missing-head", stream: { ...stream, personId: "person-synth-0017-missing-head" } };
+      const failure = await expectFailure<TutorD1Failure>(append(db, missingCommand), (error) => errorReason(error) === "EMPTY_STREAM", "missing head");
+      const after = await rowCounts(db);
+      assert(JSON.stringify(before) === JSON.stringify(after), "missing head changed rows");
+      return caseRecord("adr-03-no-stream-creation", "rejected", "EMPTY_STREAM", missingCommand.commandId, before, after, ["candidate"], { failureTag: errorTag(failure), noWrite: true });
+    }),
+  );
+  const accepted = await appendAcceptedCase();
+  cases.push(accepted.record);
+  cases.push(
+    await withSeed(async ({ db }) => {
+      const acceptedResult = await append(db, FIXTURE_COMMAND);
+      assert(acceptedResult._tag === "AcceptedResult", "replay fixture append failed");
+      const before = await rowCounts(db);
+      const replay = (await readReplay(db)) as { readonly events: ReadonlyArray<EventEnvelopeV1>; readonly folded: { readonly events: ReadonlyArray<EventEnvelopeV1> } };
+      assert(replay.events.map((event) => event.eventId).join(",") === "evt-0014-001,evt-0014-002,evt-0014-003,evt-0014-004", "replay event order mismatch");
+      assert(replay.folded.events.length === 4, "replay fold count mismatch");
+      const after = await rowCounts(db);
+      return caseRecord("adr-05-replay-accepted", "accepted", "REPLAY_ACCEPTED", FIXTURE_COMMAND.commandId, before, after, ["fixture", "replay"], { eventOrder: replay.events.map((event) => event.eventId), streamVersion: 4 });
+    }),
+  );
+  cases.push(
+    await withSeed(async ({ db }) => {
+      await append(db, FIXTURE_COMMAND);
+      const before = await rowCounts(db);
+      const malformed = { ...FIXTURE_COMMAND, commandId: "cmd-0014-malformed", extraField: "reject" };
+      const failure = await expectFailure<TutorD1Failure>(append(db, malformed), (error) => errorReason(error) === "DECODE_ERROR", "malformed command");
+      const after = await rowCounts(db);
+      assert(JSON.stringify(before) === JSON.stringify(after), "malformed command changed rows");
+      return caseRecord("adr-06-malformed", "rejected", "DECODE_ERROR", malformed.commandId, before, after, ["candidate"], { failureTag: errorTag(failure), noWrite: true });
+    }),
+  );
+  cases.push(
+    await withMigration(async ({ db }) => {
+      const before = await rowCounts(db);
+      const command = { ...FIXTURE_COMMAND, commandId: "cmd-0017-missing-head", stream: { ...stream, personId: "person-synth-0017-missing-head" } };
+      const failure = await expectFailure<TutorD1Failure>(append(db, command), (error) => errorReason(error) === "EMPTY_STREAM", "missing head classification");
+      const after = await rowCounts(db);
+      assert(JSON.stringify(before) === JSON.stringify(after), "missing head classification wrote rows");
+      return caseRecord("adr-07-empty-stream", "rejected", "EMPTY_STREAM", command.commandId, before, after, ["candidate"], { failureTag: errorTag(failure) });
+    }),
+  );
+  cases.push(
+    await withSeed(async ({ db }) => {
+      const before = await rowCounts(db);
+      const headBefore = await readFixtureHead(db);
+      assert(headBefore !== null, "divergence preflight head missing");
+      await dbExec(db, `UPDATE stream_heads SET current_version = 2, last_command_id = ?1 WHERE person_id = ?2;`, ["diverged-head", stream.personId]);
+      const failure = await expectFailure<TutorD1Failure>(append(db, { ...FIXTURE_COMMAND, commandId: "cmd-0017-divergence" }), (error) => errorTag(error) === "D1IntegrityError", "head divergence");
+      const after = await rowCounts(db);
+      const headAfter = await readFixtureHead(db);
+      assert(headAfter !== null && headBefore.current_version === 3 && headBefore.last_command_id === FIXTURE_ID, "divergence preflight head mismatch");
+      assert(headAfter.current_version === 2 && headAfter.last_command_id === "diverged-head", "divergence head was repaired");
+      assert(after.tutor_events === before.tutor_events && after.command_receipts === before.command_receipts, "divergence changed event or receipt rows");
+      return caseRecord("adr-08-head-event-divergence", "drift", "D1_INTEGRITY", "cmd-0017-divergence", before, after, ["fixture", "candidate"], { failureTag: errorTag(failure), preservedHead: true, headBefore, headAfter });
+    }),
+  );
+  cases.push(
+    await withSeed(async ({ db }) => {
+      const before = await rowCounts(db);
+      const headBefore = await readFixtureHead(db);
+      assert(headBefore !== null, "stale preflight head missing");
+      const command = { ...FIXTURE_COMMAND, commandId: "cmd-0014-stale", expectedVersion: 2 };
+      const failure = await expectFailure<TutorD1Failure>(append(db, command), (error) => errorReason(error) === "STALE_VERSION", "stale version");
+      const after = await rowCounts(db);
+      const headAfter = await readFixtureHead(db);
+      assert(headAfter !== null && JSON.stringify(headBefore) === JSON.stringify(headAfter), "stale changed head");
+      assert(JSON.stringify(before) === JSON.stringify(after), "stale changed rows");
+      return caseRecord("adr-09-stale-version", "stale", "STALE_VERSION", command.commandId, before, after, ["candidate"], { failureTag: errorTag(failure), headBefore, headAfter });
+    }),
+  );
+  cases.push(
+    await withSeed(async ({ db }) => {
+      await append(db, FIXTURE_COMMAND);
+      const before = await rowCounts(db);
+      const command = { ...FIXTURE_COMMAND, commandId: "cmd-0014-terminal", expectedVersion: 4 };
+      const failure = await expectFailure<TutorD1Failure>(append(db, command), (error) => errorReason(error) === "TERMINAL_CONDUCTED", "terminal command");
+      const after = await rowCounts(db);
+      assert(JSON.stringify(before) === JSON.stringify(after), "terminal changed rows");
+      return caseRecord("adr-10-terminal", "terminal", "TERMINAL_CONDUCTED", command.commandId, before, after, ["fixture", "candidate"], { failureTag: errorTag(failure) });
+    }),
+  );
+  cases.push(
+    await withSeed(async ({ db }) => {
+      await append(db, FIXTURE_COMMAND);
+      const before = await rowCounts(db);
+      const duplicate = await append(db, FIXTURE_COMMAND);
+      assert(duplicate._tag === "DuplicateResult", "exact duplicate did not return stored result");
+      const after = await rowCounts(db);
+      assert(JSON.stringify(before) === JSON.stringify(after), "duplicate changed rows");
+      return caseRecord("adr-11-global-duplicate", "duplicate", "DUPLICATE_IDEMPOTENT", FIXTURE_COMMAND.commandId, before, after, ["fixture", "ledger"], { resultBytesEqual: duplicate.resultBytes.length > 0, terminalValidationSkipped: true });
+    }),
+  );
+  cases.push(
+    await withSeed(async ({ db }) => {
+      await append(db, FIXTURE_COMMAND);
+      const before = await rowCounts(db);
+      const command = { ...FIXTURE_COMMAND, stream: { ...stream, personId: "person-synth-0014-other" } };
+      const failure = await expectFailure<TutorD1Failure>(append(db, command), (error) => errorReason(error) === "DUPLICATE_COMMAND_CONFLICT", "changed global duplicate");
+      const after = await rowCounts(db);
+      assert(JSON.stringify(before) === JSON.stringify(after), "duplicate conflict changed rows");
+      return caseRecord("adr-12-cross-stream-duplicate", "duplicate-conflict", "DUPLICATE_COMMAND_CONFLICT", FIXTURE_COMMAND.commandId, before, after, ["fixture", "ledger"], { failureTag: errorTag(failure), streamValidationSkipped: true });
+    }),
+  );
+  cases.push(
+    await withSeed(async ({ db }) => {
+      const before = await rowCounts(db);
+      const headBefore = await readFixtureHead(db);
+      assert(headBefore !== null, "race preflight head missing");
+      let markAReady: () => void = () => {};
+      let markBReady: () => void = () => {};
+      let releaseA: () => void = () => {};
+      let releaseB: () => void = () => {};
+      const readyA = new Promise<void>((resolve) => { markAReady = resolve; });
+      const readyB = new Promise<void>((resolve) => { markBReady = resolve; });
+      const allowA = new Promise<void>((resolve) => { releaseA = resolve; });
+      const allowB = new Promise<void>((resolve) => { releaseB = resolve; });
+      const bothReady = Promise.all([readyA, readyB]);
+      const commandA = { ...FIXTURE_COMMAND, commandId: "cmd-0017-race-a" };
+      const commandB = { ...FIXTURE_COMMAND, commandId: "cmd-0017-race-b" };
+      const capture = (command: typeof commandA, markReady: () => void, allow: Promise<void>) =>
+        append(db, command, {
+          beforeBatch: async (_plan) => {
+            markReady();
+            await bothReady;
+            await allow;
+          },
+        }).then((result) => ({ ok: true as const, result })).catch((error) => ({ ok: false as const, error }));
+      const outcomeAPromise = capture(commandA, markAReady, allowA);
+      const outcomeBPromise = capture(commandB, markBReady, allowB);
+      await bothReady;
+      releaseA();
+      const outcomeA = await outcomeAPromise;
+      assert(outcomeA.ok && outcomeA.result._tag === "AcceptedResult", "race A did not win");
+      releaseB();
+      const outcomeB = await outcomeBPromise;
+      assert(!outcomeB.ok && errorReason(outcomeB.error) === "STALE_VERSION", "race B was not stale");
+      const after = await rowCounts(db);
+      const headAfter = await readFixtureHead(db);
+      assert(headAfter !== null && headAfter.current_version === 4 && headAfter.last_command_id === commandA.commandId, "race winner head mismatch");
+      assert(after.tutor_events === before.tutor_events + 1 && after.command_receipts === before.command_receipts + 1, "race wrote more than one append");
+      return caseRecord("adr-13-same-version-race", "accepted", "RACE_ONE_CAS_WINNER", `${commandA.commandId}|${commandB.commandId}`, before, after, ["competing-writer", "candidate"], { outcomeTags: ["A:AcceptedResult", "B:StaleState:STALE_VERSION"], headBefore, headAfter });
+    }),
+  );
+  cases.push(
+    await withSeed(async ({ db }) => {
+      const before = await rowCounts(db);
+      const headBefore = await readFixtureHead(db);
+      assert(headBefore !== null, "older-event preflight head missing");
+      const oldEvent = conductedEventFor("cmd-0017-old-event");
+      const candidateCommand = { ...FIXTURE_COMMAND, commandId: "cmd-0017-advance-a" };
+      let candidatePlan: BatchPlan | undefined;
+      const failure = await expectFailure<TutorD1Failure>(append(db, candidateCommand, {
+        beforeBatch: async (plan) => {
+          candidatePlan = plan;
+          await dbExec(db, `INSERT INTO tutor_events (person_id, department_id, semester_year, semester_term, event_id, stream_version, schema_version, event_type, envelope_bytes, occurred_at, causation_id, correlation_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12);`, [stream.personId, stream.cycle.departmentId, stream.cycle.semester.year, stream.cycle.semester.term, oldEvent.eventId, oldEvent.streamVersion, oldEvent.schemaVersion, oldEvent.eventType, canonicalJsonBytes(oldEvent), oldEvent.occurredAt, oldEvent.causationId, oldEvent.correlationId]);
+          await dbExec(db, `UPDATE stream_heads SET current_version = ?1, last_command_id = ?2 WHERE person_id = ?3 AND department_id = ?4 AND semester_year = ?5 AND semester_term = ?6;`, [4, oldEvent.causationId, stream.personId, stream.cycle.departmentId, stream.cycle.semester.year, stream.cycle.semester.term]);
+        },
+      }), (error) => errorReason(error) === "STALE_VERSION", "older event causation FK");
+      const after = await rowCounts(db);
+      const headAfter = await readFixtureHead(db);
+      assert(candidatePlan !== undefined, "older-event candidate plan missing");
+      const candidateEventBinds = candidatePlan.statements[1].binds;
+      const candidateReceiptBinds = candidatePlan.statements[2].binds;
+      const candidateCausationId = candidateEventBinds[5];
+      assert(candidatePlan.commandId === candidateCommand.commandId && candidatePlan.eventId === oldEvent.eventId && candidatePlan.newVersion === oldEvent.streamVersion, "older-event candidate plan identity mismatch");
+      assert(candidateCausationId === candidateCommand.commandId && candidateCausationId !== oldEvent.causationId, "older-event candidate causation mismatch");
+      assert(candidateReceiptBinds[4] === candidateCommand.commandId && candidateReceiptBinds[9] === candidatePlan.eventId && candidateReceiptBinds[10] === candidatePlan.newVersion, "older-event receipt plan mismatch");
+      const fkCandidateReceipt = { eventId: candidateReceiptBinds[9], eventStreamVersion: candidateReceiptBinds[10], commandId: candidateReceiptBinds[4] };
+      const existingOldEvent = (await dbRows<Record<string, unknown>>(db, `SELECT event_id, stream_version, causation_id FROM tutor_events WHERE event_id = ?1 AND stream_version = ?2;`, [oldEvent.eventId, oldEvent.streamVersion]))[0];
+      assert(headAfter !== null && headAfter.current_version === 4 && headAfter.last_command_id === oldEvent.causationId, "older-event setup head mismatch");
+      assert(existingOldEvent?.event_id === candidatePlan.eventId && existingOldEvent.stream_version === candidatePlan.newVersion && existingOldEvent.causation_id === oldEvent.causationId, "older-event causation fixture mismatch");
+      assert(fkCandidateReceipt.eventId === existingOldEvent.event_id && fkCandidateReceipt.eventStreamVersion === existingOldEvent.stream_version && fkCandidateReceipt.commandId === candidateCausationId, "older-event FK candidate mismatch");
+      assert(after.stream_heads === before.stream_heads && after.tutor_events === before.tutor_events + 1 && after.command_receipts === before.command_receipts, "older event candidate was not rolled back");
+      return caseRecord("adr-14a-older-event-causation", "stale", "STALE_VERSION", candidateCommand.commandId, before, after, ["fixture-setup", "candidate"], { failureTag: errorTag(failure), setupCausationId: existingOldEvent.causation_id, candidateCausationId, receiptAttachment: false, fkRejected: true, fkColumns: ["person_id", "department_id", "semester_year", "semester_term", "event_id", "event_stream_version", "command_id"], fkExistingEvent: { eventId: existingOldEvent.event_id, streamVersion: existingOldEvent.stream_version, causationId: existingOldEvent.causation_id }, fkCandidateReceipt, candidateRollback: true, headBefore, headAfter });
+    }),
+  );
+  cases.push(
+    await withSeed(async ({ db }) => {
+      const before = await rowCounts(db);
+      const headBefore = await readFixtureHead(db);
+      assert(headBefore !== null, "beyond-version preflight head missing");
+      const failure = await expectFailure<TutorD1Failure>(append(db, { ...FIXTURE_COMMAND, commandId: "cmd-0017-advance-a" }, {
+        beforeBatch: async () => {
+          await dbExec(db, `UPDATE stream_heads SET current_version = 5, last_command_id = ?1 WHERE person_id = ?2;`, ["cmd-0017-advance-b", stream.personId]);
+        },
+      }), (error) => errorReason(error) === "STALE_VERSION", "beyond version race");
+      const after = await rowCounts(db);
+      const headAfter = await readFixtureHead(db);
+      assert(headAfter !== null && headAfter.current_version === 5 && headAfter.last_command_id === "cmd-0017-advance-b", "beyond-version setup head mismatch");
+      assert(after.tutor_events === before.tutor_events && after.command_receipts === before.command_receipts, "beyond-version batch left candidate rows");
+      return caseRecord("adr-14b-beyond-version", "stale", "STALE_VERSION", "cmd-0017-advance-a", before, after, ["fixture-setup", "candidate"], { failureTag: errorTag(failure), setupHeadVersion: 5, setupHeadToken: "cmd-0017-advance-b", lawfulFifthEvent: false, candidateRollback: true, headBefore, headAfter });
+    }),
+  );
+  cases.push(
+    await withSeed(async ({ db }) => {
+      const before = await rowCounts(db);
+      const headBefore = await readFixtureHead(db);
+      assert(headBefore !== null, "receipt-conflict preflight head missing");
+      const competingCommand = { ...FIXTURE_COMMAND, correlationId: "corr-0017-competing" };
+      const event = { ...conductedEventFor(FIXTURE_COMMAND.commandId), eventId: "evt-0017-receipt-competing", streamVersion: 5 };
+      const observation = observationFor(FIXTURE_COMMAND.commandId);
+      const failure = await expectFailure<TutorD1Failure>(append(db, { ...FIXTURE_COMMAND }, {
+        beforeBatch: async (_plan) => {
+          await dbExec(db, `INSERT INTO tutor_events (person_id, department_id, semester_year, semester_term, event_id, stream_version, schema_version, event_type, envelope_bytes, occurred_at, causation_id, correlation_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12);`, [stream.personId, stream.cycle.departmentId, stream.cycle.semester.year, stream.cycle.semester.term, event.eventId, event.streamVersion, event.schemaVersion, event.eventType, canonicalJsonBytes(event), event.occurredAt, event.causationId, event.correlationId]);
+          await dbExec(db, `INSERT INTO command_receipts (person_id, department_id, semester_year, semester_term, command_id, command_bytes, command_sha256, result_bytes, descriptor_bytes, event_id, event_stream_version) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11);`, [stream.personId, stream.cycle.departmentId, stream.cycle.semester.year, stream.cycle.semester.term, FIXTURE_COMMAND.commandId, canonicalJsonBytes(competingCommand), sha256Hex(canonicalJsonBytes(competingCommand)), canonicalJsonBytes(observation), canonicalJsonBytes(observation.descriptor), event.eventId, event.streamVersion]);
+        },
+      }), (error) => errorReason(error) === "DUPLICATE_COMMAND_CONFLICT", "receipt primary-key conflict");
+      const after = await rowCounts(db);
+      const headAfter = await readFixtureHead(db);
+      assert(headAfter !== null && JSON.stringify(headBefore) === JSON.stringify(headAfter), "receipt conflict changed head");
+      assert(after.stream_heads === before.stream_heads && after.tutor_events === before.tutor_events + 1 && after.command_receipts === before.command_receipts + 1, "receipt conflict candidate changed rows");
+      return caseRecord("adr-15a-receipt-primary-key", "duplicate-conflict", "DUPLICATE_COMMAND_CONFLICT", FIXTURE_COMMAND.commandId, before, after, ["fixture-setup", "competing-writer", "candidate"], { uniqueness: "command_receipts PRIMARY KEY", failureTag: errorTag(failure), candidateRollback: true, secondLedgerClassification: true, headBefore, headAfter });
+    }),
+  );
+  cases.push(
+    await withSeed(async ({ db }) => {
+      const before = await rowCounts(db);
+      const headBefore = await readFixtureHead(db);
+      assert(headBefore !== null, "event-unique preflight head missing");
+      const event = conductedEventFor("cmd-0017-event-unique");
+      const failure = await expectFailure<TutorD1Failure>(append(db, { ...FIXTURE_COMMAND, commandId: "cmd-0017-event-unique" }, {
+        beforeBatch: async () => {
+          await dbExec(db, `INSERT INTO tutor_events (person_id, department_id, semester_year, semester_term, event_id, stream_version, schema_version, event_type, envelope_bytes, occurred_at, causation_id, correlation_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12);`, [stream.personId, stream.cycle.departmentId, stream.cycle.semester.year, stream.cycle.semester.term, event.eventId, event.streamVersion, event.schemaVersion, event.eventType, canonicalJsonBytes(event), event.occurredAt, event.causationId, event.correlationId]);
+        },
+      }), (error) => errorTag(error) === "D1BatchError", "event uniqueness failure");
+      const after = await rowCounts(db);
+      const headAfter = await readFixtureHead(db);
+      assert(headAfter !== null && JSON.stringify(headBefore) === JSON.stringify(headAfter), "event uniqueness changed head");
+      assert(after.stream_heads === before.stream_heads && after.tutor_events === before.tutor_events + 1 && after.command_receipts === before.command_receipts, "event uniqueness candidate changed rows");
+      return caseRecord("adr-15b-event-unique", "drift", "D1_BATCH_FAILURE", "cmd-0017-event-unique", before, after, ["fixture-setup", "candidate"], { failureTag: errorTag(failure), uniqueness: "tutor_events stream_version/event_id", candidateRollback: true, headBefore, headAfter });
+    }),
+  );
+  cases.push(
+    await withSeed(async ({ db }) => {
+      await append(db, FIXTURE_COMMAND);
+      const before = await rowCounts(db);
+      const event = (await dbRows<Record<string, unknown>>(db, `SELECT event_id FROM tutor_events WHERE event_id = ?1;`, ["evt-0014-004"]))[0];
+      assert(event !== undefined, "trigger fixture event missing");
+      const triggerErrors: string[] = [];
+      for (const sql of ["UPDATE tutor_events SET occurred_at = occurred_at WHERE event_id = 'evt-0014-004';", "DELETE FROM tutor_events WHERE event_id = 'evt-0014-004';", "UPDATE command_receipts SET command_sha256 = command_sha256 WHERE command_id = 'cmd-0014-conduct';", "DELETE FROM command_receipts WHERE command_id = 'cmd-0014-conduct';"]) {
+        try {
+          await dbExec(db, sql);
+        } catch (error) {
+          triggerErrors.push(error instanceof Error ? error.message : String(error));
+        }
+      }
+      assert(triggerErrors.length === 4, "not all immutable trigger operations failed");
+      assert(triggerErrors.every((message) => message.includes("immutable")), "immutable trigger message missing");
+      const after = await rowCounts(db);
+      assert(JSON.stringify(before) === JSON.stringify(after), "trigger operations changed rows");
+      return caseRecord("adr-16-immutable-triggers", "rejected", "IMMUTABLE_TRIGGER_ABORT", FIXTURE_COMMAND.commandId, before, after, ["fixture", "trigger"], { triggerMessages: triggerErrors.map((message) => message.includes("tutor_events") ? "tutor_events are immutable" : "command_receipts are immutable") });
+    }),
+  );
+  cases.push(
+    await withSeed(async ({ db }) => {
+      await append(db, FIXTURE_COMMAND);
+      const rows = (await dbRows<Record<string, unknown>>(db, REPLAY_SQL, [stream.personId, stream.cycle.departmentId, stream.cycle.semester.year, stream.cycle.semester.term])) as unknown as ReadonlyArray<ReplayEventRow>;
+      const normalizedRows = rows.map((row) => ({ ...row, envelope_bytes: Array.from(normalizeBlobBytes(row.envelope_bytes)) }));
+      const replay = await runWithTutorD1(db as unknown as D1Binding, validateReplayRows(stream, normalizedRows));
+      assert(replay.events.length === 4 && replay.folded.events.length === 4, "number-array normalization did not replay");
+      const before = await rowCounts(db);
+      const after = await rowCounts(db);
+      return caseRecord("adr-17-number-array-blob", "accepted", "BLOB_NORMALIZED", FIXTURE_COMMAND.commandId, before, after, ["fixture", "adapter-boundary"], { runtimeType: "number[]", normalizedType: "Uint8Array", fatalUtf8: true, exactReencode: true });
+    }),
+  );
+  cases.push(
+    await withSeed(async ({ db }) => {
+      const rows = (await dbRows<Record<string, unknown>>(db, REPLAY_SQL, [stream.personId, stream.cycle.departmentId, stream.cycle.semester.year, stream.cycle.semester.term])) as unknown as ReadonlyArray<ReplayEventRow>;
+      const wrongValues: ReadonlyArray<unknown> = ["not-bytes", { bytes: [1, 2] }, null, [0, 256]];
+      const failures: string[] = [];
+      for (const wrong of wrongValues) {
+        try {
+          await runWithTutorD1(db as unknown as D1Binding, validateReplayRows(stream, [{ ...rows[0]!, envelope_bytes: wrong }]));
+        } catch (error) {
+          failures.push(`${errorTag(error)}:${errorReason(error)}`);
+        }
+      }
+      assert(failures.length === wrongValues.length && failures.every((failure) => failure.startsWith("D1IntegrityError:D1_INTEGRITY")), "wrong BLOB values did not fail closed");
+      const counts = await rowCounts(db);
+      return caseRecord("adr-18-wrong-blob-runtime-type", "drift", "BLOB_INTEGRITY_FAILURE", "adapter-boundary", counts, counts, ["fixture", "adapter-boundary"], { failures, foldInvoked: false, descriptorExposed: false });
+    }),
+  );
+  cases.push(
+    await withSeed(async ({ db }) => {
+      assert(accepted.result._tag === "AcceptedResult", "accepted SQL plan missing");
+      const acceptedResult = accepted.result;
+      const before = await rowCounts(db);
+      const headBefore = await readFixtureHead(db);
+      assert(headBefore !== null, "stale SQL preflight head missing");
+      const staleCommand = { ...FIXTURE_COMMAND, commandId: "cmd-0017-sql-stale" };
+      let stalePlan: BatchPlan | undefined;
+      const stale = await expectFailure<TutorD1Failure>(append(db, staleCommand, {
+        beforeBatch: async (plan) => {
+          stalePlan = plan;
+          await dbExec(db, `UPDATE stream_heads SET current_version = current_version + 1, last_command_id = ?1 WHERE person_id = ?2;`, ["cmd-0017-sql-race", stream.personId]);
+        },
+      }), (error) => errorReason(error) === "STALE_VERSION", "stale SQL batch");
+      assert(stalePlan !== undefined, "stale batch plan was not captured");
+      const acceptedSql = acceptedResult.batchPlan.statements.map((statement) => statement.sql);
+      const staleSql = stalePlan.statements.map((statement) => statement.sql);
+      const sqlTexts = [...acceptedSql, ...staleSql];
+      assert(sqlTexts.every((sql) => /\?[0-9]+/.test(sql) && !/:[a-zA-Z]/.test(sql)), "SQL placeholder contract failed");
+      assert(acceptedResult.batchPlan.statements[0]?.binds.length === 7 && acceptedResult.batchPlan.statements[1]?.binds.length === 12 && acceptedResult.batchPlan.statements[2]?.binds.length === 11, "bind cardinality mismatch");
+      const after = await rowCounts(db);
+      const headAfter = await readFixtureHead(db);
+      assert(headBefore.current_version === 3 && headBefore.last_command_id === FIXTURE_ID, "stale SQL preflight head mismatch");
+      assert(headAfter !== null && headAfter.current_version === 4 && headAfter.last_command_id === "cmd-0017-sql-race", "stale SQL setup head mismatch");
+      assert(JSON.stringify(before) === JSON.stringify(after), "stale SQL batch changed rows");
+      return caseRecord("adr-19-numbered-sql-binds", "stale", "NUMBERED_SQL_VERIFIED", staleCommand.commandId, before, after, ["candidate", "batch-result"], { sqlTexts, bindOrder: { accepted: acceptedResult.batchPlan.statements.map((statement) => statement.binds), stale: stalePlan.statements.map((statement) => statement.binds) }, resultIndexes: [0, 1, 2], resultZero: acceptedResult.batchResults[0], staleFailure: `${errorTag(stale)}:${errorReason(stale)}`, headBefore, headAfter });
+    }),
+  );
+  cases.push(await replayCases());
+
+  const acceptedReplay = await withSeed(async ({ db }) => {
+    await append(db, FIXTURE_COMMAND);
+    const result = (await readReplay(db)) as ReplayResult;
+    const projection = projectFoldedState(result.folded);
+    const counts = await rowCounts(db);
+    return { result, projection, counts };
+  });
+  const descriptor = accepted.observation.descriptor;
+  const reasonCounts: Record<string, number> = {};
+  for (const item of cases) reasonCounts[item.reasonCode] = (reasonCounts[item.reasonCode] ?? 0) + 1;
+  return {
+    formatVersion: 1,
+    specId: SPEC_ID,
+    baseCommit: BASE_COMMIT,
+    adrSha256: ADR_SHA256,
+    predecessorCommit: PREDECESSOR_COMMIT,
+    fixtureId: FIXTURE_ID,
+    schemaMigrationId: "0017-0001-tutor-event-store",
+    schemaHash,
+    localEffectVersion: EFFECT_VERSION,
+    localEffectSourceHashes: {
+      d1Client: D1_CLIENT_SOURCE_HASH,
+      statement: STATEMENT_SOURCE_HASH,
+      sqlEventJournal: SQL_EVENT_JOURNAL_SOURCE_HASH,
+      migrator: MIGRATOR_SOURCE_HASH,
+      sqlClient: SQL_CLIENT_SOURCE_HASH,
+    },
+    localMiniflareVersion: MINIFLARE_VERSION,
+    correlationId: FIXTURE_CORRELATION_ID,
+    stream,
+    seedHead: {
+      person_id: FIXTURE_PERSON_ID,
+      department_id: FIXTURE_DEPARTMENT_ID,
+      semester_year: 2026,
+      semester_term: "Vår",
+      current_version: 3,
+      last_command_id: FIXTURE_ID,
+    },
+    seedEvents: FIXTURE_SEED_EVENTS.map((event) => ({ eventId: event.eventId, streamVersion: event.streamVersion, eventType: event.eventType, occurredAt: event.occurredAt, causationId: event.causationId, correlationId: event.correlationId })),
+    batch: {
+      accepted: accepted.plan,
+      stale: cases.find((item) => item.caseId === "adr-19-numbered-sql-binds")?.details,
+      resultIndexes: [0, 1, 2],
+      exactBindCardinality: [7, 12, 11],
+    },
+    cases,
+    replay: {
+      query: REPLAY_SQL,
+      bindOrder: ["personId", "departmentId", "semesterYear", "semesterTerm"],
+      eventOrder: acceptedReplay.result.events.map((event) => event.eventId),
+      decoder: ["ApplicationReceived:1", "InterviewInvited:1", "InterviewAccepted:1", "InterviewConducted:1"],
+      persistedBadRowsFailClosed: true,
+      adapterArrayLimit: ["duplicate-event-id", "duplicate-stream-version", "cross-stream-row"],
+    },
+    projection: acceptedReplay.projection,
+    effectDescriptors: [descriptor],
+    rowCounts: {
+      finalCanonicalStream: acceptedReplay.counts,
+      acceptedStreamVersion: 4,
+      acceptedReceiptCount: 1,
+      eventIds: acceptedReplay.result.events.map((event) => event.eventId),
+    },
+    limits: [
+      "local-miniflare-only",
+      "one-disposable-binding-per-journey-run-reset-between-cases",
+      "no-provider-or-remote-binding",
+      "no-worker-route-or-public-url",
+      "no-credentials-or-production-data",
+      "no-remote-d1-result-shape-proof",
+      "no-replica-session-or-bookmark-proof",
+      "no-deployment-cutover-or-operator-proof",
+      "no-status-or-projection-table",
+      "descriptor-is-inert-and-not-interpreted",
+      "adapter-array-duplicate-and-cross-stream-cases-are-fold-input-only",
+    ],
+    provenance: {
+      pinnedBunVersion: PINNED_BUN_VERSION,
+      miniflareSetup: { modules: true, script: "", d1Binding: D1_BINDING_NAME, operation: "D1Database.prepare(...).run" },
+      migrationAppliedOrder: ["0017-0001-tutor-event-store"],
+      reasonCounts,
+      sourceCommit: BASE_COMMIT,
+      sourceCandidateParent: SOURCE_CANDIDATE_PARENT,
+      sourceCandidateCommit: SOURCE_CANDIDATE_COMMIT,
+      canonicalIntegrationBase: CANONICAL_INTEGRATION_BASE,
+      canonicalD1IntegrationCommit: CANONICAL_D1_INTEGRATION_COMMIT,
+      noNetwork: true,
+    },
+  };
+  } finally {
+    activeRuntime = undefined;
+    await runtime.miniflare.dispose();
+  }
+};
+
+const replayCases = async (): Promise<CaseRecord> => {
+  type BadRow = {
+    readonly caseId: string;
+    readonly reasonCode: string;
+    readonly makeEvent: (base: EventEnvelopeV1) => {
+      readonly event: EventEnvelopeV1;
+      readonly indexed: Readonly<Record<string, unknown>>;
+    };
+  };
+  const badRows: ReadonlyArray<BadRow> = [
+    { caseId: "unknown-schema", reasonCode: "UNKNOWN_DECODER", makeEvent: (base) => ({ event: base, indexed: { schema_version: 99 } }) },
+    { caseId: "version-gap", reasonCode: "REPLAY_FOLD", makeEvent: (base) => ({ event: { ...base, streamVersion: 5 }, indexed: {} }) },
+    { caseId: "occurred-at-rewind", reasonCode: "REPLAY_FOLD", makeEvent: (base) => ({ event: { ...base, occurredAt: "2026-08-11T08:59:00Z" }, indexed: {} }) },
+    { caseId: "correlation-mismatch", reasonCode: "REPLAY_FOLD", makeEvent: (base) => ({ event: { ...base, correlationId: "corr-0017-other" }, indexed: {} }) },
+    { caseId: "indexed-envelope-mismatch", reasonCode: "ROW_INDEX_MISMATCH", makeEvent: (base) => ({ event: base, indexed: { event_id: "evt-0017-index" } }) },
+    { caseId: "decoded-envelope-stream-mismatch", reasonCode: "ROW_INDEX_MISMATCH", makeEvent: (base) => ({ event: { ...base, stream: { ...stream, personId: "person-synth-0017-other" } }, indexed: {} }) },
+  ];
+  const insertReplayRow = async (db: LocalBinding, event: EventEnvelopeV1, indexed: Readonly<Record<string, unknown>>): Promise<void> => {
+    const row = {
+      person_id: stream.personId,
+      department_id: stream.cycle.departmentId,
+      semester_year: stream.cycle.semester.year,
+      semester_term: stream.cycle.semester.term,
+      event_id: event.eventId,
+      stream_version: event.streamVersion,
+      schema_version: event.schemaVersion,
+      event_type: event.eventType,
+      envelope_bytes: canonicalJsonBytes(event),
+      occurred_at: event.occurredAt,
+      causation_id: event.causationId,
+      correlation_id: event.correlationId,
+      ...indexed,
+    };
+    await dbExec(db, `INSERT INTO tutor_events (person_id, department_id, semester_year, semester_term, event_id, stream_version, schema_version, event_type, envelope_bytes, occurred_at, causation_id, correlation_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12);`, [row.person_id, row.department_id, row.semester_year, row.semester_term, row.event_id, row.stream_version, row.schema_version, row.event_type, row.envelope_bytes, row.occurred_at, row.causation_id, row.correlation_id]);
+  };
+  const observations: string[] = [];
+  for (const bad of badRows) {
+    await withSeed(async ({ db }) => {
+      const before = await rowCounts(db);
+      const { event, indexed } = bad.makeEvent(conductedEventFor(`cmd-0017-replay-${bad.caseId}`));
+      await insertReplayRow(db, event, indexed);
+      const failure = await expectFailure<TutorD1Failure>(readReplay(db), (error) => errorTag(error) === "D1IntegrityError", `persisted replay ${bad.caseId}`);
+      assert(errorReason(failure) === "D1_INTEGRITY", `persisted replay ${bad.caseId} did not enter Drift`);
+      const after = await rowCounts(db);
+      assert(after.tutor_events === before.tutor_events + 1 && after.command_receipts === before.command_receipts, `persisted replay ${bad.caseId} changed unexpected rows`);
+      observations.push(`${bad.caseId}:persisted:D1IntegrityError:${bad.reasonCode}`);
+    });
+  }
+  await withSeed(async ({ db }) => {
+    const rows = (await dbRows<Record<string, unknown>>(db, REPLAY_SQL, [stream.personId, stream.cycle.departmentId, stream.cycle.semester.year, stream.cycle.semester.term])) as unknown as ReadonlyArray<ReplayEventRow>;
+    const duplicateFailure = await expectFailure<TutorD1Failure>(runWithTutorD1(db as unknown as D1Binding, validateReplayRows(stream, [rows[0]!, rows[0]!, rows[1]!])), (error) => errorTag(error) === "D1IntegrityError", "adapter duplicate event");
+    const crossStreamFailure = await expectFailure<TutorD1Failure>(runWithTutorD1(db as unknown as D1Binding, validateReplayRows(stream, [{ ...rows[0]!, person_id: "person-synth-0017-other" }])), (error) => errorTag(error) === "D1IntegrityError", "adapter cross-stream row");
+    observations.push(`duplicate-event-id-version:adapter:${errorReason(duplicateFailure)}`, `cross-stream-row:adapter:${errorReason(crossStreamFailure)}`);
+  });
+  return withSeed(async ({ db }) => {
+    const before = await rowCounts(db);
+    const valid = (await readReplay(db)) as { readonly events: ReadonlyArray<EventEnvelopeV1>; readonly folded: { readonly events: ReadonlyArray<EventEnvelopeV1> } };
+    assert(valid.events.length === 3 && valid.folded.events.length === 3, "valid replay baseline failed");
+    const after = await rowCounts(db);
+    return caseRecord("adr-20-replay-integrity", "rejected", "REPLAY_BAD_ROWS_FAIL_CLOSED", "replay", before, after, ["fresh-persisted-row", "adapter-row-array"], { observations, validEventOrder: valid.events.map((event) => event.eventId), localPersistenceLimit: ["duplicate-event-id", "duplicate-stream-version", "cross-stream-row"] });
+  });
+};
+
+const canonicalEvidenceJson = (evidence: D1Evidence): string => {
+  const entries: ReadonlyArray<readonly [string, unknown]> = [
+    ["formatVersion", evidence.formatVersion],
+    ["specId", evidence.specId],
+    ["baseCommit", evidence.baseCommit],
+    ["adrSha256", evidence.adrSha256],
+    ["predecessorCommit", evidence.predecessorCommit],
+    ["fixtureId", evidence.fixtureId],
+    ["schemaMigrationId", evidence.schemaMigrationId],
+    ["schemaHash", evidence.schemaHash],
+    ["localEffectVersion", evidence.localEffectVersion],
+    ["localEffectSourceHashes", evidence.localEffectSourceHashes],
+    ["localMiniflareVersion", evidence.localMiniflareVersion],
+    ["correlationId", evidence.correlationId],
+    ["stream", evidence.stream],
+    ["seedHead", evidence.seedHead],
+    ["seedEvents", evidence.seedEvents],
+    ["batch", evidence.batch],
+    ["cases", evidence.cases],
+    ["replay", evidence.replay],
+    ["projection", evidence.projection],
+    ["effectDescriptors", evidence.effectDescriptors],
+    ["rowCounts", evidence.rowCounts],
+    ["limits", evidence.limits],
+    ["provenance", evidence.provenance],
+  ];
+  return `{${entries.map(([key, value]) => `${JSON.stringify(key)}:${canonicalJson(value)}`).join(",")}}`;
+};
+
+const renderEvidence = (document: D1Evidence): RenderedEvidence => {
+  const canonical = canonicalEvidenceJson(document);
+  const bytes = new TextEncoder().encode(`${canonical}\n`);
+  return { document, canonicalJson: canonical, bytes, digest: sha256Hex(bytes) };
+};
+
+export interface D1ProofRun {
+  readonly passed: true;
+  readonly evidence: RenderedEvidence;
+  readonly secondRender: RenderedEvidence;
+  readonly reasonCounts: Readonly<Record<string, number>>;
+}
+
+export const runD1Proof = async (): Promise<D1ProofRun> => {
+  const sql = await migrationSql();
+  const schemaHash = sha256Hex(new TextEncoder().encode(sql));
+  const first = await runJourney(schemaHash);
+  const second = await runJourney(schemaHash);
+  const firstBase = renderEvidence(first);
+  const secondBase = renderEvidence(second);
+  assert(firstBase.digest === secondBase.digest, "clean local evidence digest changed");
+  assert(firstBase.bytes.length === secondBase.bytes.length && firstBase.bytes.every((byte, index) => byte === secondBase.bytes[index]), "clean local evidence bytes changed");
+  const repeatDetails = {
+    firstByteLength: firstBase.bytes.length,
+    secondByteLength: secondBase.bytes.length,
+    firstSha256: firstBase.digest,
+    secondSha256: secondBase.digest,
+    byteIdentical: true,
+  };
+  const finalDocument: D1Evidence = {
+    ...first,
+    cases: [...first.cases, caseRecord("adr-21-evidence-repeatability", "accepted", "EVIDENCE_REPEATABLE", FIXTURE_COMMAND.commandId, { stream_heads: 1, tutor_events: 4, command_receipts: 1 }, { stream_heads: 1, tutor_events: 4, command_receipts: 1 }, ["clean-run-a", "clean-run-b"], repeatDetails)],
+    provenance: { ...first.provenance, twoRunCanonicalEvidence: repeatDetails },
+  };
+  const firstRender = renderEvidence(finalDocument);
+  const secondRender = renderEvidence(finalDocument);
+  assert(firstRender.canonicalJson === secondRender.canonicalJson, "same-document evidence JSON changed");
+  assert(firstRender.bytes.length === secondRender.bytes.length && firstRender.bytes.every((byte, index) => byte === secondRender.bytes[index]), "same-document evidence bytes changed");
+  const reasonCounts: Record<string, number> = {};
+  for (const item of finalDocument.cases) reasonCounts[item.reasonCode] = (reasonCounts[item.reasonCode] ?? 0) + 1;
+  return { passed: true, evidence: firstRender, secondRender, reasonCounts };
+};
+
+export const main = async (args: ReadonlyArray<string> = process.argv.slice(2)): Promise<number> => {
+  if (args.length !== 0) {
+    process.stderr.write("usage: bun run src/tutor/d1-proof.ts\n");
+    return 1;
+  }
+  try {
+    const run = await runD1Proof();
+    process.stdout.write(`${canonicalJson({
+      specId: SPEC_ID,
+      passed: run.passed,
+      caseCount: run.evidence.document.cases.length,
+      reasonCounts: run.reasonCounts,
+      evidenceByteLength: run.evidence.bytes.length,
+      evidenceSha256: run.evidence.digest,
+      secondEvidenceSha256: run.secondRender.digest,
+      byteIdentical: run.evidence.bytes.every((byte, index) => byte === run.secondRender.bytes[index]),
+    })}\n${run.evidence.canonicalJson}\n`);
+    return 0;
+  } catch (error) {
+    process.stderr.write(`${canonicalJson({ specId: SPEC_ID, passed: false, error: `${errorTag(error)}:${errorReason(error)}` })}\n`);
+    return 1;
+  }
+};
+
+if (import.meta.main) process.exitCode = await main();

--- a/packages/domain/src/tutor/d1.ts
+++ b/packages/domain/src/tutor/d1.ts
@@ -1,0 +1,713 @@
+import * as D1Client from "@effect/sql-d1/D1Client";
+import { Effect, Schema } from "effect";
+import {
+  canonicalJsonBytes,
+  canonicalJson,
+  sha256Hex,
+} from "./evidence.js";
+import {
+  ConductInterviewV1Schema,
+  DescriptorSchema,
+  decodeConductInterviewV1,
+  decodeEventEnvelopeV1,
+  type ConductInterviewV1,
+  type Descriptor,
+  type EventEnvelopeV1,
+  type StreamKey,
+} from "./schema.js";
+import {
+  DuplicateCommandConflict,
+  InvalidTransition,
+  StaleState,
+  conductInterview,
+  foldEvents,
+  type CommandObservation,
+  type FoldedState,
+  type TutorFailure,
+} from "./tracer.js";
+
+export type D1Binding = Parameters<typeof D1Client.layer>[0]["db"];
+
+export type D1IntegrityReason =
+  | "BLOB_RUNTIME_TYPE"
+  | "BLOB_UTF8"
+  | "BLOB_NON_CANONICAL"
+  | "ROW_SHAPE"
+  | "ROW_STREAM"
+  | "ROW_INDEX_MISMATCH"
+  | "UNKNOWN_DECODER"
+  | "REPLAY_FOLD"
+  | "HEAD_MISMATCH"
+  | "RESULT_SHAPE"
+  | "EMPTY_STREAM";
+
+export class D1IntegrityError extends Error {
+  readonly _tag = "D1IntegrityError";
+  readonly reasonCode = "D1_INTEGRITY";
+  readonly lifecycle = "Drift";
+
+  constructor(readonly reason: D1IntegrityReason, detail: string) {
+    super(`${reason}: ${detail}`);
+    this.name = "D1IntegrityError";
+  }
+}
+
+export class D1BatchError extends Error {
+  readonly _tag = "D1BatchError";
+  readonly reasonCode = "D1_BATCH_FAILURE";
+  readonly lifecycle = "Drift";
+
+  constructor(
+    readonly operation: "read" | "append",
+    readonly detail: string,
+    readonly causeValue?: unknown,
+  ) {
+    super(`${operation} batch failed: ${detail}`);
+    this.name = "D1BatchError";
+  }
+}
+
+export type TutorD1Failure = TutorFailure | D1IntegrityError | D1BatchError;
+
+export interface StreamHead {
+  readonly person_id: string;
+  readonly department_id: string;
+  readonly semester_year: number;
+  readonly semester_term: "Vår" | "Høst";
+  readonly current_version: number;
+  readonly last_command_id: string | null;
+}
+
+export interface ReplayEventRow {
+  readonly person_id: unknown;
+  readonly department_id: unknown;
+  readonly semester_year: unknown;
+  readonly semester_term: unknown;
+  readonly event_id: unknown;
+  readonly stream_version: unknown;
+  readonly schema_version: unknown;
+  readonly event_type: unknown;
+  readonly envelope_bytes: unknown;
+  readonly occurred_at: unknown;
+  readonly causation_id: unknown;
+  readonly correlation_id: unknown;
+}
+
+export interface ReplayResult {
+  readonly rows: ReadonlyArray<ReplayEventRow>;
+  readonly events: ReadonlyArray<EventEnvelopeV1>;
+  readonly folded: FoldedState;
+}
+
+export interface StoredReceipt {
+  readonly commandId: string;
+  readonly commandBytes: Uint8Array;
+  readonly resultBytes: Uint8Array;
+  readonly descriptorBytes: Uint8Array;
+  readonly result: unknown;
+  readonly descriptor: Descriptor;
+}
+
+export interface D1AcceptedAppend {
+  readonly _tag: "AcceptedResult";
+  readonly observation: CommandObservation;
+  readonly commandBytes: Uint8Array;
+  readonly resultBytes: Uint8Array;
+  readonly descriptorBytes: Uint8Array;
+  readonly event: EventEnvelopeV1;
+  readonly batchPlan: BatchPlan;
+  readonly batchResults: ReadonlyArray<ReadonlyArray<Record<string, unknown>>>;
+}
+
+export interface D1DuplicateAppend {
+  readonly _tag: "DuplicateResult";
+  readonly receipt: StoredReceipt;
+  readonly resultBytes: Uint8Array;
+  readonly descriptorBytes: Uint8Array;
+}
+
+export type D1AppendResult = D1AcceptedAppend | D1DuplicateAppend;
+
+export interface BatchPlan {
+  readonly statements: readonly [
+    { readonly sql: string; readonly binds: ReadonlyArray<unknown> },
+    { readonly sql: string; readonly binds: ReadonlyArray<unknown> },
+    { readonly sql: string; readonly binds: ReadonlyArray<unknown> },
+  ];
+  readonly newVersion: number;
+  readonly commandId: string;
+  readonly eventId: string;
+}
+
+export const RECEIPT_LOOKUP_SQL = `SELECT command_id, command_bytes, result_bytes, descriptor_bytes
+FROM command_receipts
+WHERE command_id = ?1;`;
+
+export const HEAD_LOOKUP_SQL = `SELECT person_id, department_id, semester_year, semester_term, current_version, last_command_id
+FROM stream_heads
+WHERE person_id = ?1
+  AND department_id = ?2
+  AND semester_year = ?3
+  AND semester_term = ?4;`;
+
+export const REPLAY_SQL = `SELECT
+  person_id,
+  department_id,
+  semester_year,
+  semester_term,
+  event_id,
+  stream_version,
+  schema_version,
+  event_type,
+  envelope_bytes,
+  occurred_at,
+  causation_id,
+  correlation_id
+FROM tutor_events
+WHERE person_id = ?1
+  AND department_id = ?2
+  AND semester_year = ?3
+  AND semester_term = ?4
+ORDER BY stream_version ASC;`;
+
+export const HEAD_CAS_SQL = `UPDATE stream_heads
+SET current_version = current_version + 1,
+    last_command_id = ?7
+WHERE person_id = ?1
+  AND department_id = ?2
+  AND semester_year = ?3
+  AND semester_term = ?4
+  AND current_version = ?5
+  AND last_command_id IS ?6
+RETURNING current_version, last_command_id;`;
+
+export const EVENT_INSERT_SQL = `INSERT INTO tutor_events (
+  person_id,
+  department_id,
+  semester_year,
+  semester_term,
+  event_id,
+  stream_version,
+  schema_version,
+  event_type,
+  envelope_bytes,
+  occurred_at,
+  causation_id,
+  correlation_id
+)
+SELECT
+  h.person_id,
+  h.department_id,
+  h.semester_year,
+  h.semester_term,
+  ?7,
+  h.current_version,
+  ?8,
+  ?9,
+  ?10,
+  ?11,
+  ?6,
+  ?12
+FROM stream_heads AS h
+WHERE h.person_id = ?1
+  AND h.department_id = ?2
+  AND h.semester_year = ?3
+  AND h.semester_term = ?4
+  AND h.current_version = ?5
+  AND h.last_command_id = ?6;`;
+
+export const RECEIPT_INSERT_SQL = `INSERT INTO command_receipts (
+  person_id,
+  department_id,
+  semester_year,
+  semester_term,
+  command_id,
+  command_bytes,
+  command_sha256,
+  result_bytes,
+  descriptor_bytes,
+  event_id,
+  event_stream_version
+)
+VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11);`;
+
+const sqlErrorDetail = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "unknown D1 error";
+};
+
+const streamEqual = (left: StreamKey, right: StreamKey): boolean =>
+  left.personId === right.personId &&
+  left.cycle.departmentId === right.cycle.departmentId &&
+  left.cycle.semester.year === right.cycle.semester.year &&
+  left.cycle.semester.term === right.cycle.semester.term;
+
+const streamBinds = (stream: StreamKey): ReadonlyArray<unknown> => [
+  stream.personId,
+  stream.cycle.departmentId,
+  stream.cycle.semester.year,
+  stream.cycle.semester.term,
+];
+
+const bytesEqual = (left: Uint8Array, right: Uint8Array): boolean =>
+  left.length === right.length && left.every((value, index) => value === right[index]);
+
+/** Strict adapter boundary. Bun Buffer coercion is deliberately not used here. */
+export const normalizeBlobBytes = (value: unknown): Uint8Array => {
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  }
+  if (Array.isArray(value) && value.every((entry) => Number.isInteger(entry) && entry >= 0 && entry <= 255)) {
+    return Uint8Array.from(value);
+  }
+  throw new D1IntegrityError("BLOB_RUNTIME_TYPE", "returned value is not a byte representation");
+};
+
+const normalizeBlob = (value: unknown, field: string): Effect.Effect<Uint8Array, D1IntegrityError> =>
+  Effect.try({
+    try: () => normalizeBlobBytes(value),
+    catch: (error) =>
+      error instanceof D1IntegrityError
+        ? error
+        : new D1IntegrityError("BLOB_RUNTIME_TYPE", `${field}: unknown byte representation`),
+  });
+
+const decodeCanonicalJson = (
+  value: unknown,
+  field: string,
+): Effect.Effect<{ readonly bytes: Uint8Array; readonly value: unknown }, D1IntegrityError> =>
+  Effect.gen(function* () {
+    const bytes = yield* normalizeBlob(value, field);
+    const text = yield* Effect.try({
+      try: () => new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+      catch: () => new D1IntegrityError("BLOB_UTF8", `${field}: invalid UTF-8`),
+    });
+    const roundTrip = new TextEncoder().encode(text);
+    if (!bytesEqual(bytes, roundTrip)) {
+      return yield* Effect.fail(new D1IntegrityError("BLOB_UTF8", `${field}: UTF-8 bytes changed`));
+    }
+    const parsed = yield* Effect.try({
+      try: () => JSON.parse(text) as unknown,
+      catch: () => new D1IntegrityError("BLOB_UTF8", `${field}: invalid JSON`),
+    });
+    const canonical = yield* Effect.try({
+      try: () => canonicalJsonBytes(parsed),
+      catch: () => new D1IntegrityError("BLOB_NON_CANONICAL", `${field}: canonical encoding failed`),
+    });
+    if (!bytesEqual(bytes, canonical)) {
+      return yield* Effect.fail(new D1IntegrityError("BLOB_NON_CANONICAL", `${field}: bytes are not canonical`));
+    }
+    return { bytes, value: parsed };
+  });
+
+const decodeStoredCommand = (
+  value: unknown,
+): Effect.Effect<{ readonly bytes: Uint8Array; readonly command: ConductInterviewV1 }, D1IntegrityError> =>
+  Effect.gen(function* () {
+    const decoded = yield* decodeCanonicalJson(value, "command_bytes");
+    const command = yield* decodeConductInterviewV1(decoded.value).pipe(
+      Effect.mapError(() => new D1IntegrityError("BLOB_NON_CANONICAL", "command_bytes: closed command decode failed")),
+    );
+    const canonical = canonicalJsonBytes(command);
+    if (!bytesEqual(decoded.bytes, canonical)) {
+      return yield* Effect.fail(new D1IntegrityError("BLOB_NON_CANONICAL", "command_bytes: decoded bytes differ"));
+    }
+    return { bytes: decoded.bytes, command };
+  });
+
+const decodeStoredDescriptor = (value: unknown): Effect.Effect<{ readonly bytes: Uint8Array; readonly descriptor: Descriptor }, D1IntegrityError> =>
+  Effect.gen(function* () {
+    const decoded = yield* decodeCanonicalJson(value, "descriptor_bytes");
+    const descriptor = yield* Schema.decodeUnknownEffect(DescriptorSchema, { onExcessProperty: "error" })(decoded.value).pipe(
+      Effect.mapError(() => new D1IntegrityError("BLOB_NON_CANONICAL", "descriptor_bytes: descriptor decode failed")),
+    );
+    return { bytes: decoded.bytes, descriptor };
+  });
+
+const queryRows = <A extends Record<string, unknown>>(
+  d1: D1Client.D1Client,
+  sql: string,
+  binds: ReadonlyArray<unknown>,
+): Effect.Effect<ReadonlyArray<A>, D1BatchError> =>
+  d1.batch([d1.unsafe<A>(sql, binds)]).pipe(
+    Effect.map((results) => ((results as unknown as ReadonlyArray<ReadonlyArray<A>>)[0] ?? [])),
+    Effect.mapError((error) => new D1BatchError("read", sqlErrorDetail(error), error)),
+  );
+
+const readHead = (
+  d1: D1Client.D1Client,
+  stream: StreamKey,
+): Effect.Effect<StreamHead | undefined, TutorD1Failure> =>
+  Effect.gen(function* () {
+    const rows = yield* queryRows<Record<string, unknown>>(d1, HEAD_LOOKUP_SQL, streamBinds(stream));
+    if (rows.length === 0) return undefined;
+    if (rows.length !== 1) return yield* Effect.fail(new D1IntegrityError("ROW_SHAPE", "head lookup returned more than one row"));
+    const row = rows[0];
+    if (row === undefined) return yield* Effect.fail(new D1IntegrityError("ROW_SHAPE", "head row disappeared"));
+    if (
+      typeof row.person_id !== "string" ||
+      typeof row.department_id !== "string" ||
+      typeof row.semester_year !== "number" ||
+      !Number.isInteger(row.semester_year) ||
+      (row.semester_term !== "Vår" && row.semester_term !== "Høst") ||
+      typeof row.current_version !== "number" ||
+      !Number.isInteger(row.current_version) ||
+      row.current_version < 0 ||
+      (row.last_command_id !== null && typeof row.last_command_id !== "string")
+    ) {
+      return yield* Effect.fail(new D1IntegrityError("ROW_SHAPE", "head row has invalid indexed values"));
+    }
+    return row as unknown as StreamHead;
+  });
+
+const eventDecoderKeys = new Set([
+  "ApplicationReceived:1",
+  "InterviewInvited:1",
+  "InterviewAccepted:1",
+  "InterviewConducted:1",
+]);
+
+const indexedStream = (row: ReplayEventRow): Effect.Effect<StreamKey, D1IntegrityError> =>
+  Effect.gen(function* () {
+    if (
+      typeof row.person_id !== "string" ||
+      typeof row.department_id !== "string" ||
+      typeof row.semester_year !== "number" ||
+      !Number.isInteger(row.semester_year) ||
+      (row.semester_term !== "Vår" && row.semester_term !== "Høst")
+    ) {
+      return yield* Effect.fail(new D1IntegrityError("ROW_SHAPE", "event stream columns have invalid values"));
+    }
+    return {
+      personId: row.person_id,
+      cycle: {
+        departmentId: row.department_id,
+        semester: { year: row.semester_year, term: row.semester_term },
+      },
+    };
+  });
+
+const decodeReplayEvent = (
+  requestedStream: StreamKey,
+  row: ReplayEventRow,
+  index: number,
+): Effect.Effect<EventEnvelopeV1, D1IntegrityError> =>
+  Effect.gen(function* () {
+    const rowStream = yield* indexedStream(row);
+    if (!streamEqual(rowStream, requestedStream)) {
+      return yield* Effect.fail(new D1IntegrityError("ROW_STREAM", `row ${index + 1} stream differs from query stream`));
+    }
+    if (
+      typeof row.event_id !== "string" ||
+      typeof row.stream_version !== "number" ||
+      !Number.isInteger(row.stream_version) ||
+      typeof row.schema_version !== "number" ||
+      !Number.isInteger(row.schema_version) ||
+      typeof row.event_type !== "string" ||
+      typeof row.occurred_at !== "string" ||
+      typeof row.causation_id !== "string" ||
+      typeof row.correlation_id !== "string"
+    ) {
+      return yield* Effect.fail(new D1IntegrityError("ROW_SHAPE", `row ${index + 1} has invalid indexed values`));
+    }
+    const decoderKey = `${row.event_type}:${row.schema_version}`;
+    if (!eventDecoderKeys.has(decoderKey)) {
+      return yield* Effect.fail(new D1IntegrityError("UNKNOWN_DECODER", decoderKey));
+    }
+    const decoded = yield* decodeCanonicalJson(row.envelope_bytes, `envelope_bytes[${index}]`);
+    const event = yield* decodeEventEnvelopeV1(decoded.value).pipe(
+      Effect.mapError(() => new D1IntegrityError("UNKNOWN_DECODER", decoderKey)),
+    );
+    const expectedIndexed = {
+      person_id: event.stream.personId,
+      department_id: event.stream.cycle.departmentId,
+      semester_year: event.stream.cycle.semester.year,
+      semester_term: event.stream.cycle.semester.term,
+      event_id: event.eventId,
+      stream_version: event.streamVersion,
+      schema_version: event.schemaVersion,
+      event_type: event.eventType,
+      occurred_at: event.occurredAt,
+      causation_id: event.causationId,
+      correlation_id: event.correlationId,
+    };
+    for (const [key, expected] of Object.entries(expectedIndexed)) {
+      if (row[key as keyof ReplayEventRow] !== expected) {
+        return yield* Effect.fail(new D1IntegrityError("ROW_INDEX_MISMATCH", `row ${index + 1} ${key} differs from envelope`));
+      }
+    }
+    if (!bytesEqual(decoded.bytes, canonicalJsonBytes(event))) {
+      return yield* Effect.fail(new D1IntegrityError("BLOB_NON_CANONICAL", `row ${index + 1} envelope bytes changed`));
+    }
+    return event;
+  });
+
+export const validateReplayRows = (
+  requestedStream: StreamKey,
+  rows: ReadonlyArray<ReplayEventRow>,
+): Effect.Effect<ReplayResult, TutorD1Failure> =>
+  Effect.gen(function* () {
+    const events: Array<EventEnvelopeV1> = [];
+    for (const [index, row] of rows.entries()) {
+      events.push(yield* decodeReplayEvent(requestedStream, row, index));
+    }
+    if (events.length === 0) {
+      return yield* Effect.fail(new D1IntegrityError("EMPTY_STREAM", "replay returned no events"));
+    }
+    const folded = yield* foldEvents(events).pipe(
+      Effect.mapError((error) => new D1IntegrityError("REPLAY_FOLD", `${error._tag}:${error.reasonCode}`)),
+    );
+    return { rows, events, folded } as ReplayResult;
+  });
+
+const readStream = (
+  d1: D1Client.D1Client,
+  stream: StreamKey,
+): Effect.Effect<ReplayResult, TutorD1Failure> =>
+  Effect.gen(function* () {
+    const rows = yield* queryRows<Record<string, unknown>>(d1, REPLAY_SQL, streamBinds(stream));
+    return yield* validateReplayRows(stream, rows as unknown as ReadonlyArray<ReplayEventRow>);
+  });
+
+const readReceipt = (
+  d1: D1Client.D1Client,
+  commandId: string,
+): Effect.Effect<StoredReceipt | undefined, TutorD1Failure> =>
+  Effect.gen(function* () {
+    const rows = yield* queryRows<Record<string, unknown>>(d1, RECEIPT_LOOKUP_SQL, [commandId]);
+    if (rows.length === 0) return undefined;
+    if (rows.length !== 1) return yield* Effect.fail(new D1IntegrityError("ROW_SHAPE", "receipt lookup returned more than one row"));
+    const row = rows[0];
+    if (row === undefined) return yield* Effect.fail(new D1IntegrityError("ROW_SHAPE", "receipt row disappeared"));
+    if (row.command_id !== commandId) {
+      return yield* Effect.fail(new D1IntegrityError("ROW_SHAPE", "receipt command ID differs from lookup"));
+    }
+    const command = yield* decodeStoredCommand(row.command_bytes);
+    if (command.command.commandId !== commandId) {
+      return yield* Effect.fail(new D1IntegrityError("ROW_INDEX_MISMATCH", "receipt command bytes differ from command_id"));
+    }
+    const result = yield* decodeCanonicalJson(row.result_bytes, "result_bytes");
+    const descriptor = yield* decodeStoredDescriptor(row.descriptor_bytes);
+    return {
+      commandId,
+      commandBytes: command.bytes,
+      resultBytes: result.bytes,
+      descriptorBytes: descriptor.bytes,
+      result: result.value,
+      descriptor: descriptor.descriptor,
+    };
+  });
+
+export const buildBatchPlan = (
+  command: ConductInterviewV1,
+  event: EventEnvelopeV1,
+  resultBytes: Uint8Array,
+  descriptorBytes: Uint8Array,
+  expectedLastCommandId: string,
+): BatchPlan => {
+  const stream = command.stream;
+  const commandBytes = canonicalJsonBytes(command);
+  const streamValues = streamBinds(stream);
+  const newVersion = command.expectedVersion + 1;
+  return {
+    newVersion,
+    commandId: command.commandId,
+    eventId: event.eventId,
+    statements: [
+      {
+        sql: HEAD_CAS_SQL,
+        binds: [...streamValues, command.expectedVersion, expectedLastCommandId, command.commandId],
+      },
+      {
+        sql: EVENT_INSERT_SQL,
+        binds: [
+          ...streamValues,
+          newVersion,
+          command.commandId,
+          event.eventId,
+          event.schemaVersion,
+          event.eventType,
+          canonicalJsonBytes(event),
+          event.occurredAt,
+          event.correlationId,
+        ],
+      },
+      {
+        sql: RECEIPT_INSERT_SQL,
+        binds: [
+          ...streamValues,
+          command.commandId,
+          commandBytes,
+          sha256Hex(commandBytes),
+          resultBytes,
+          descriptorBytes,
+          event.eventId,
+          newVersion,
+        ],
+      },
+    ],
+  };
+};
+const classifyBatchFailure = (
+  d1: D1Client.D1Client,
+  command: ConductInterviewV1,
+  expectedHead: StreamHead,
+  original: D1BatchError,
+): Effect.Effect<D1AppendResult, TutorD1Failure> =>
+  Effect.gen(function* () {
+    const commandBytes = canonicalJsonBytes(command);
+    const competingReceipt = yield* readReceipt(d1, command.commandId);
+    if (competingReceipt !== undefined) {
+      if (bytesEqual(competingReceipt.commandBytes, commandBytes)) {
+        return {
+          _tag: "DuplicateResult" as const,
+          receipt: competingReceipt,
+          resultBytes: competingReceipt.resultBytes,
+          descriptorBytes: competingReceipt.descriptorBytes,
+        };
+      }
+      return yield* Effect.fail(new DuplicateCommandConflict(command.commandId));
+    }
+    const currentHead = yield* readHead(d1, command.stream);
+    if (currentHead === undefined) {
+      return yield* Effect.fail(new InvalidTransition("EMPTY_STREAM", undefined));
+    }
+    if (
+      currentHead.current_version !== expectedHead.current_version ||
+      currentHead.last_command_id !== expectedHead.last_command_id
+    ) {
+      return yield* Effect.fail(new StaleState(command.expectedVersion, currentHead.current_version));
+    }
+    return yield* Effect.fail(original);
+  });
+
+export interface AppendOptions {
+  readonly beforeBatch?: ((plan: BatchPlan) => Promise<void>) | undefined;
+}
+
+const appendAccepted = (
+  d1: D1Client.D1Client,
+  input: unknown,
+  options?: AppendOptions,
+): Effect.Effect<D1AppendResult, TutorD1Failure> => {
+  let preflightHead: StreamHead | undefined;
+  return Effect.gen(function* () {
+    const command = yield* decodeConductInterviewV1(input);
+    const commandBytes = canonicalJsonBytes(command);
+    const prior = yield* readReceipt(d1, command.commandId);
+    if (prior !== undefined) {
+      if (bytesEqual(prior.commandBytes, commandBytes)) {
+        return {
+          _tag: "DuplicateResult" as const,
+          receipt: prior,
+          resultBytes: prior.resultBytes,
+          descriptorBytes: prior.descriptorBytes,
+        };
+      }
+      return yield* Effect.fail(new DuplicateCommandConflict(command.commandId));
+    }
+
+    const head = yield* readHead(d1, command.stream);
+    if (head === undefined) return yield* Effect.fail(new InvalidTransition("EMPTY_STREAM", undefined));
+    preflightHead = head;
+    const replay = yield* readStream(d1, command.stream);
+    if (head.current_version !== replay.events.length) {
+      return yield* Effect.fail(new D1IntegrityError("HEAD_MISMATCH", "head version differs from folded event count"));
+    }
+    const lastEvent = replay.events[replay.events.length - 1];
+    if (lastEvent === undefined || head.last_command_id !== lastEvent.causationId) {
+      return yield* Effect.fail(new D1IntegrityError("HEAD_MISMATCH", "head token differs from last event causation"));
+    }
+
+    const transition = yield* conductInterview(
+      {
+        stream: replay.folded.stream,
+        events: replay.events,
+        receipts: [],
+      },
+      command,
+    );
+    if (transition._tag !== "AcceptedResult") {
+      return yield* Effect.fail(new D1IntegrityError("RESULT_SHAPE", "accepted append transition returned duplicate"));
+    }
+    const event = transition.state.events[transition.state.events.length - 1];
+    if (event === undefined) return yield* Effect.fail(new D1IntegrityError("RESULT_SHAPE", "accepted transition had no event"));
+    const resultBytes = canonicalJsonBytes(transition.observation);
+    const descriptorBytes = canonicalJsonBytes(transition.observation.descriptor);
+    const plan = buildBatchPlan(command, event, resultBytes, descriptorBytes, lastEvent.causationId);
+
+    if (options?.beforeBatch !== undefined) {
+      yield* Effect.promise(() => options.beforeBatch!(plan));
+    }
+
+    const result = yield* d1.batch([
+      d1.unsafe<Record<string, unknown>>(plan.statements[0].sql, plan.statements[0].binds),
+      d1.unsafe<Record<string, unknown>>(plan.statements[1].sql, plan.statements[1].binds),
+      d1.unsafe<Record<string, unknown>>(plan.statements[2].sql, plan.statements[2].binds),
+    ]).pipe(
+      Effect.mapError((error) => new D1BatchError("append", sqlErrorDetail(error), error)),
+    );
+    const resultZero = (result[0] ?? []) as ReadonlyArray<Record<string, unknown>>;
+    if (
+      resultZero.length !== 1 ||
+      resultZero[0]?.current_version !== plan.newVersion ||
+      resultZero[0]?.last_command_id !== command.commandId
+    ) {
+      return yield* Effect.fail(new D1IntegrityError("RESULT_SHAPE", "batch result 0 did not verify the CAS row"));
+    }
+    return {
+      _tag: "AcceptedResult" as const,
+      observation: transition.observation,
+      commandBytes,
+      resultBytes,
+      descriptorBytes,
+      event,
+      batchPlan: plan,
+      batchResults: result as unknown as ReadonlyArray<ReadonlyArray<Record<string, unknown>>>,
+    } satisfies D1AcceptedAppend;
+  }).pipe(
+    Effect.catchTag("D1BatchError", (error) =>
+      Effect.gen(function* () {
+        const command = yield* decodeConductInterviewV1(input);
+        if (preflightHead === undefined) return yield* Effect.fail(error);
+        return yield* classifyBatchFailure(d1, command, preflightHead, error);
+      }),
+    ),
+  );
+};
+
+export const makeTutorD1Store = Effect.gen(function* () {
+  const d1 = yield* D1Client.D1Client;
+  return {
+    readStream: (stream: StreamKey) => readStream(d1, stream),
+    findReceipt: (commandId: string) => readReceipt(d1, commandId),
+    appendAccepted: (input: unknown, options?: AppendOptions) => appendAccepted(d1, input, options),
+  } as const;
+});
+
+export type TutorD1Store = Effect.Success<typeof makeTutorD1Store>;
+
+export const runWithTutorD1 = <A, E>(
+  db: D1Binding,
+  effect: Effect.Effect<A, E, D1Client.D1Client>,
+): Promise<A> =>
+  Effect.runPromise(
+    Effect.scoped(effect.pipe(Effect.provide(D1Client.layer({ db })))) as Effect.Effect<A, E>,
+  );
+
+export const decodePersistedResult = (value: unknown): unknown => {
+  const bytes = normalizeBlobBytes(value);
+  const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  const parsed = JSON.parse(text) as unknown;
+  if (!bytesEqual(bytes, canonicalJsonBytes(parsed))) {
+    throw new D1IntegrityError("BLOB_NON_CANONICAL", "persisted result is not canonical");
+  }
+  return parsed;
+};
+
+export const commandSchema = ConductInterviewV1Schema;
+export const canonicalCommand = canonicalJson;
+export const streamKeyBinds = streamBinds;
+export const streamKeysEqual = streamEqual;

--- a/packages/domain/src/tutor/migrations/0001-tutor-event-store.sql
+++ b/packages/domain/src/tutor/migrations/0001-tutor-event-store.sql
@@ -1,0 +1,97 @@
+CREATE TABLE stream_heads (
+  person_id TEXT NOT NULL,
+  department_id TEXT NOT NULL,
+  semester_year INTEGER NOT NULL,
+  semester_term TEXT NOT NULL CHECK (semester_term IN ('Vår', 'Høst')),
+  current_version INTEGER NOT NULL CHECK (current_version >= 0),
+  last_command_id TEXT,
+  PRIMARY KEY (person_id, department_id, semester_year, semester_term),
+  CHECK (
+    (current_version = 0 AND last_command_id IS NULL)
+    OR (current_version > 0 AND last_command_id IS NOT NULL)
+  )
+) STRICT;
+
+CREATE TABLE tutor_events (
+  person_id TEXT NOT NULL,
+  department_id TEXT NOT NULL,
+  semester_year INTEGER NOT NULL,
+  semester_term TEXT NOT NULL CHECK (semester_term IN ('Vår', 'Høst')),
+  event_id TEXT NOT NULL,
+  stream_version INTEGER NOT NULL CHECK (stream_version > 0),
+  schema_version INTEGER NOT NULL CHECK (schema_version > 0),
+  event_type TEXT NOT NULL,
+  envelope_bytes BLOB NOT NULL CHECK (typeof(envelope_bytes) = 'blob'),
+  occurred_at TEXT NOT NULL,
+  causation_id TEXT NOT NULL,
+  correlation_id TEXT NOT NULL,
+  PRIMARY KEY (person_id, department_id, semester_year, semester_term, event_id),
+  UNIQUE (person_id, department_id, semester_year, semester_term, stream_version),
+  UNIQUE (
+    person_id,
+    department_id,
+    semester_year,
+    semester_term,
+    event_id,
+    stream_version,
+    causation_id
+  ),
+  FOREIGN KEY (person_id, department_id, semester_year, semester_term)
+    REFERENCES stream_heads (person_id, department_id, semester_year, semester_term)
+) STRICT;
+
+CREATE TABLE command_receipts (
+  person_id TEXT NOT NULL,
+  department_id TEXT NOT NULL,
+  semester_year INTEGER NOT NULL,
+  semester_term TEXT NOT NULL CHECK (semester_term IN ('Vår', 'Høst')),
+  command_id TEXT NOT NULL,
+  command_bytes BLOB NOT NULL CHECK (typeof(command_bytes) = 'blob'),
+  command_sha256 TEXT NOT NULL,
+  result_bytes BLOB NOT NULL CHECK (typeof(result_bytes) = 'blob'),
+  descriptor_bytes BLOB NOT NULL CHECK (typeof(descriptor_bytes) = 'blob'),
+  event_id TEXT NOT NULL,
+  event_stream_version INTEGER NOT NULL CHECK (event_stream_version > 0),
+  PRIMARY KEY (command_id),
+  FOREIGN KEY (
+    person_id,
+    department_id,
+    semester_year,
+    semester_term,
+    event_id,
+    event_stream_version,
+    command_id
+  ) REFERENCES tutor_events (
+    person_id,
+    department_id,
+    semester_year,
+    semester_term,
+    event_id,
+    stream_version,
+    causation_id
+  )
+) STRICT;
+
+CREATE TRIGGER tutor_events_immutable_update
+BEFORE UPDATE ON tutor_events
+BEGIN
+  SELECT RAISE(ABORT, 'tutor_events are immutable');
+END;
+
+CREATE TRIGGER tutor_events_immutable_delete
+BEFORE DELETE ON tutor_events
+BEGIN
+  SELECT RAISE(ABORT, 'tutor_events are immutable');
+END;
+
+CREATE TRIGGER command_receipts_immutable_update
+BEFORE UPDATE ON command_receipts
+BEGIN
+  SELECT RAISE(ABORT, 'command_receipts are immutable');
+END;
+
+CREATE TRIGGER command_receipts_immutable_delete
+BEFORE DELETE ON command_receipts
+BEGIN
+  SELECT RAISE(ABORT, 'command_receipts are immutable');
+END;


### PR DESCRIPTION
## Design spec
`design-specs/0017-tutor-d1-event-store-proof.md`

## Journey
A maintainer runs the tutor command lifecycle against the bounded D1-compatible event-store proof, observes append/receipt behavior, and verifies rejected or failed writes leave stream heads unchanged.

## Experience it
1. Check out this stacked branch.
2. Run `bun --cwd packages/domain proof:d1` as recorded in the spec.
3. Inspect all deterministic cases, receipt attachment, rollback, and provenance fields.

## Evidence
- 23 deterministic cases pass twice with byte-identical output.
- Focused typecheck passes; independent code/runtime review passes.
- Provenance fields identify source candidate and canonical integration commits without dangling parent semantics.

## What is real
The local D1-compatible SQL proof and failure atomicity are executable. This does not claim a deployed D1 binding, Worker route, scheduling, provider behavior, migration of production data, or production acceptance.
